### PR TITLE
feat: show runtime column with live elapsed time for non-finished runs

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { formatRuntime, computeRuntime } from './api'
+import {
+  getRuntime,
+  getStartTimestamp,
+  getEndTimestamp,
+  isFinished,
+  formatDurationMs,
+  getStageStatus,
+} from './api'
 import type { RunMetadata } from './api'
 
 function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
@@ -15,109 +22,217 @@ function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
   }
 }
 
-function ts(isoString: string): Record<string, unknown> {
-  return { timestamp: isoString }
-}
+const ts = (iso: string) => ({ timestamp: iso })
 
-describe('formatRuntime', () => {
-  it('returns dash for negative diff', () => {
-    expect(formatRuntime(-1000)).toBe('—')
+describe('formatDurationMs', () => {
+  it('returns — for negative durations', () => {
+    expect(formatDurationMs(-1000)).toBe('—')
   })
 
-  it('returns 0m for zero diff', () => {
-    expect(formatRuntime(0)).toBe('0m')
+  it('formats seconds', () => {
+    expect(formatDurationMs(45_000)).toBe('45s')
   })
 
-  it('returns minutes only when less than an hour', () => {
-    expect(formatRuntime(30 * 60_000)).toBe('30m')
+  it('formats minutes and seconds', () => {
+    expect(formatDurationMs(125_000)).toBe('2m 5s')
   })
 
-  it('returns hours and minutes for longer durations', () => {
-    expect(formatRuntime(90 * 60_000)).toBe('1h 30m')
+  it('formats hours and minutes', () => {
+    expect(formatDurationMs(3_723_000)).toBe('1h 2m')
   })
 
-  it('returns hours and 0m for exact hours', () => {
-    expect(formatRuntime(2 * 3600_000)).toBe('2h 0m')
-  })
-
-  it('truncates seconds (does not round)', () => {
-    // 59 seconds = 0m
-    expect(formatRuntime(59_000)).toBe('0m')
-    // 61 seconds = 1m
-    expect(formatRuntime(61_000)).toBe('1m')
+  it('returns 0s for zero', () => {
+    expect(formatDurationMs(0)).toBe('0s')
   })
 })
 
-describe('computeRuntime', () => {
-  it('returns null for pending jobs (no start metadata)', () => {
-    const meta = makeMetadata({ init: { timestamp: '2025-01-01T00:00:00Z' } })
-    expect(computeRuntime(meta)).toBeNull()
+describe('getStartTimestamp', () => {
+  it('returns init timestamp when available', () => {
+    const m = makeMetadata({ init: ts('2025-01-01T10:00:00Z') })
+    expect(getStartTimestamp(m)).toBe(new Date('2025-01-01T10:00:00Z').getTime())
   })
 
-  it('returns null when no metadata at all', () => {
-    const meta = makeMetadata()
-    expect(computeRuntime(meta)).toBeNull()
+  it('falls back to runInferStart when init has no timestamp', () => {
+    const m = makeMetadata({
+      init: { foo: 'bar' },
+      runInferStart: ts('2025-01-01T11:00:00Z'),
+    })
+    expect(getStartTimestamp(m)).toBe(new Date('2025-01-01T11:00:00Z').getTime())
   })
 
-  it('computes total runtime for a completed job', () => {
-    const meta = makeMetadata({
+  it('returns null when no timestamps exist', () => {
+    const m = makeMetadata()
+    expect(getStartTimestamp(m)).toBeNull()
+  })
+})
+
+describe('getEndTimestamp', () => {
+  it('returns evalInferEnd for completed runs', () => {
+    const m = makeMetadata({
       init: ts('2025-01-01T10:00:00Z'),
       runInferStart: ts('2025-01-01T10:05:00Z'),
       runInferEnd: ts('2025-01-01T11:00:00Z'),
       evalInferStart: ts('2025-01-01T11:05:00Z'),
-      evalInferEnd: ts('2025-01-01T12:30:00Z'),
+      evalInferEnd: ts('2025-01-01T12:00:00Z'),
     })
-    // 2h 30m from init to evalInferEnd
-    expect(computeRuntime(meta)).toBe('2h 30m')
+    expect(getEndTimestamp(m)).toBe(new Date('2025-01-01T12:00:00Z').getTime())
   })
 
-  it('computes total runtime for an errored job', () => {
-    const meta = makeMetadata({
+  it('returns error timestamp for errored runs', () => {
+    const m = makeMetadata({
       init: ts('2025-01-01T10:00:00Z'),
       runInferStart: ts('2025-01-01T10:05:00Z'),
-      error: ts('2025-01-01T10:45:00Z'),
+      error: ts('2025-01-01T10:30:00Z'),
     })
-    // 45m from init to error
-    expect(computeRuntime(meta)).toBe('45m')
+    expect(getEndTimestamp(m)).toBe(new Date('2025-01-01T10:30:00Z').getTime())
   })
 
-  it('computes elapsed time for a running job (running-infer)', () => {
-    const meta = makeMetadata({
+  it('returns null for running-infer (not finished)', () => {
+    const m = makeMetadata({
       init: ts('2025-01-01T10:00:00Z'),
       runInferStart: ts('2025-01-01T10:05:00Z'),
     })
-    const fakeNow = new Date('2025-01-01T11:30:00Z').getTime()
-    // 1h 30m from init to now
-    expect(computeRuntime(meta, fakeNow)).toBe('1h 30m')
+    expect(getEndTimestamp(m)).toBeNull()
   })
 
-  it('computes elapsed time for a running job (running-eval)', () => {
-    const meta = makeMetadata({
-      init: ts('2025-01-01T08:00:00Z'),
-      runInferStart: ts('2025-01-01T08:05:00Z'),
-      runInferEnd: ts('2025-01-01T09:00:00Z'),
-      evalInferStart: ts('2025-01-01T09:10:00Z'),
+  it('returns null for running-eval (not finished)', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+      runInferEnd: ts('2025-01-01T11:00:00Z'),
+      evalInferStart: ts('2025-01-01T11:05:00Z'),
     })
-    const fakeNow = new Date('2025-01-01T10:15:00Z').getTime()
-    // 2h 15m from init to now
-    expect(computeRuntime(meta, fakeNow)).toBe('2h 15m')
+    expect(getEndTimestamp(m)).toBeNull()
+  })
+})
+
+describe('isFinished', () => {
+  it('returns true for completed', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      evalInferEnd: ts('2025-01-01T12:00:00Z'),
+    })
+    expect(isFinished(m)).toBe(true)
   })
 
-  it('uses runInferStart as start time when init is missing', () => {
-    const meta = makeMetadata({
-      runInferStart: ts('2025-01-01T10:00:00Z'),
-      runInferEnd: ts('2025-01-01T10:30:00Z'),
-      evalInferStart: ts('2025-01-01T10:35:00Z'),
-      evalInferEnd: ts('2025-01-01T11:00:00Z'),
+  it('returns true for error', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      error: ts('2025-01-01T10:30:00Z'),
     })
-    // 1h from runInferStart to evalInferEnd
-    expect(computeRuntime(meta)).toBe('1h 0m')
+    expect(isFinished(m)).toBe(true)
   })
 
-  it('returns null when timestamp field is missing from data', () => {
-    const meta = makeMetadata({
-      runInferStart: { someOtherField: 'value' },
+  it('returns false for running-infer', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
     })
-    expect(computeRuntime(meta)).toBeNull()
+    expect(isFinished(m)).toBe(false)
+  })
+
+  it('returns false for pending', () => {
+    const m = makeMetadata({ init: ts('2025-01-01T10:00:00Z') })
+    expect(isFinished(m)).toBe(false)
+  })
+})
+
+describe('getRuntime', () => {
+  it('returns formatted duration for completed run', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+      runInferEnd: ts('2025-01-01T11:00:00Z'),
+      evalInferStart: ts('2025-01-01T11:05:00Z'),
+      evalInferEnd: ts('2025-01-01T12:00:00Z'),
+    })
+    expect(getRuntime(m)).toBe('2h 0m')
+  })
+
+  it('returns formatted duration for errored run', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+      error: ts('2025-01-01T10:30:00Z'),
+    })
+    expect(getRuntime(m)).toBe('30m 0s')
+  })
+
+  it('uses current time (now param) for non-finished runs', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+    })
+    const fakeNow = new Date('2025-01-01T10:20:00Z').getTime()
+    expect(getRuntime(m, fakeNow)).toBe('20m 0s')
+  })
+
+  it('uses current time for pending runs with init', () => {
+    const m = makeMetadata({ init: ts('2025-01-01T10:00:00Z') })
+    const fakeNow = new Date('2025-01-01T10:03:00Z').getTime()
+    expect(getRuntime(m, fakeNow)).toBe('3m 0s')
+  })
+
+  it('uses current time for running-eval', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+      runInferEnd: ts('2025-01-01T11:00:00Z'),
+      evalInferStart: ts('2025-01-01T11:05:00Z'),
+    })
+    const fakeNow = new Date('2025-01-01T12:30:00Z').getTime()
+    expect(getRuntime(m, fakeNow)).toBe('2h 30m')
+  })
+
+  it('returns null when no start timestamp exists', () => {
+    const m = makeMetadata()
+    expect(getRuntime(m)).toBeNull()
+  })
+
+  it('returns null for metadata with no timestamps at all', () => {
+    const m = makeMetadata({ init: { foo: 'bar' } })
+    expect(getRuntime(m)).toBeNull()
+  })
+})
+
+describe('getStageStatus', () => {
+  it('returns error when error exists', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+      error: ts('2025-01-01T10:30:00Z'),
+    })
+    expect(getStageStatus(m)).toBe('error')
+  })
+
+  it('returns completed when evalInferEnd exists', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      evalInferEnd: ts('2025-01-01T12:00:00Z'),
+    })
+    expect(getStageStatus(m)).toBe('completed')
+  })
+
+  it('returns running-infer when only runInferStart', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+    })
+    expect(getStageStatus(m)).toBe('running-infer')
+  })
+
+  it('returns running-eval when evalInferStart exists', () => {
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+      runInferEnd: ts('2025-01-01T11:00:00Z'),
+      evalInferStart: ts('2025-01-01T11:05:00Z'),
+    })
+    expect(getStageStatus(m)).toBe('running-eval')
+  })
+
+  it('returns pending when only init', () => {
+    const m = makeMetadata({ init: ts('2025-01-01T10:00:00Z') })
+    expect(getStageStatus(m)).toBe('pending')
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -91,39 +91,52 @@ function getTimestampMs(data: Record<string, unknown> | null): number | null {
   return isNaN(ms) ? null : ms
 }
 
-export function formatRuntime(diffMs: number): string {
-  if (diffMs < 0) return '—'
-  const totalMinutes = Math.floor(diffMs / 60000)
-  const hours = Math.floor(totalMinutes / 60)
-  const minutes = totalMinutes % 60
-  if (hours > 0) return `${hours}h ${minutes}m`
-  return `${minutes}m`
+export function getStartTimestamp(metadata: RunMetadata): number | null {
+  return getTimestampMs(metadata.init)
+    ?? getTimestampMs(metadata.runInferStart)
+    ?? null
 }
 
-export function computeRuntime(metadata: RunMetadata, now?: number): string | null {
+export function getEndTimestamp(metadata: RunMetadata): number | null {
   const status = getStageStatus(metadata)
-  if (status === 'pending') return null
-
-  // Find the earliest start time
-  const startMs =
-    getTimestampMs(metadata.init) ??
-    getTimestampMs(metadata.runInferStart) ??
-    getTimestampMs(metadata.evalInferStart)
-  if (startMs == null) return null
-
-  // For completed or errored jobs, use the latest available end timestamp
-  if (status === 'completed' || status === 'error') {
-    const endMs =
-      getTimestampMs(metadata.evalInferEnd) ??
-      getTimestampMs(metadata.runInferEnd) ??
-      getTimestampMs(metadata.error) ??
-      getTimestampMs(metadata.evalInferStart) ??
-      getTimestampMs(metadata.runInferStart)
-    if (endMs == null) return null
-    return formatRuntime(endMs - startMs)
+  if (status === 'completed') {
+    return getTimestampMs(metadata.evalInferEnd) ?? null
   }
+  if (status === 'error') {
+    return getTimestampMs(metadata.error)
+      ?? getTimestampMs(metadata.evalInferStart)
+      ?? getTimestampMs(metadata.runInferEnd)
+      ?? getTimestampMs(metadata.runInferStart)
+      ?? getTimestampMs(metadata.init)
+      ?? null
+  }
+  return null
+}
 
-  // For running jobs, compute elapsed time from now
-  const currentMs = now ?? Date.now()
-  return formatRuntime(currentMs - startMs)
+export function isFinished(metadata: RunMetadata): boolean {
+  const status = getStageStatus(metadata)
+  return status === 'completed' || status === 'error'
+}
+
+export function formatDurationMs(ms: number): string {
+  if (ms < 0) return '—'
+  const seconds = Math.floor(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return `${hours}h ${remainingMinutes}m`
+}
+
+export function getRuntime(metadata: RunMetadata, now: number = Date.now()): string | null {
+  const start = getStartTimestamp(metadata)
+  if (start === null) return null
+
+  const finished = isFinished(metadata)
+  const end = finished ? getEndTimestamp(metadata) : now
+  if (end === null) return null
+
+  return formatDurationMs(end - start)
 }

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import type { RunMetadata } from '../api'
-import { getStageStatus, computeRuntime } from '../api'
+import { getStageStatus, getRuntime, isFinished } from '../api'
 
 interface RunInfo {
   slug: string
@@ -99,23 +99,32 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
   const [filterText, setFilterText] = useState('')
   const [now, setNow] = useState(Date.now())
 
-  // Tick every 60s so running job runtimes update live
+  // Check if any run is non-finished to decide whether to tick the timer
+  const hasNonFinished = useMemo(() => {
+    return runs.some(run => {
+      const metadata = runMetadataMap[run.slug]
+      return metadata && !isFinished(metadata)
+    })
+  }, [runs, runMetadataMap])
+
+  // Tick every 1s so elapsed time updates for non-finished runs
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 60_000)
-    return () => clearInterval(id)
-  }, [])
+    if (!hasNonFinished) return
+    const interval = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [hasNonFinished])
 
   // Compute statuses, runtimes, and triggered-by
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
       const metadata = runMetadataMap[run.slug]
       const status: StatusType = metadata ? getStageStatus(metadata) : 'pending'
-      const runtime: string | null = metadata ? computeRuntime(metadata, now) : null
+      const runtime: string | null = metadata ? getRuntime(metadata, now) : null
+      const runFinished = metadata ? isFinished(metadata) : true
       const triggeredBy = extractTriggeredBy(metadata)
-      return { ...run, status, runtime, triggeredBy }
+      return { ...run, status, runtime, runFinished, triggeredBy }
     })
   }, [runs, runMetadataMap, now])
-
 
   const benchmarks = useMemo(() => [...new Set(runs.map(r => r.benchmark))].sort(), [runs])
   const statuses = useMemo(() => [...new Set(runsWithStatus.map(r => r.status))].sort(), [runsWithStatus])
@@ -298,9 +307,14 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
                       </span>
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">
-                      <span className="text-sm text-oh-text-muted font-mono">
-                        {run.runtime ?? '—'}
-                      </span>
+                      {run.runtime ? (
+                        <span className={`text-sm font-mono ${run.runFinished ? 'text-oh-text-muted' : 'text-oh-primary'}`}>
+                          {run.runtime}
+                          {!run.runFinished && <span className="ml-1 text-xs opacity-60">⏱</span>}
+                        </span>
+                      ) : (
+                        <span className="text-sm text-oh-text-muted">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">
                       <span className="text-sm text-oh-text-muted">


### PR DESCRIPTION
## Summary

Fixes #11 — The runtime column now shows elapsed time for **all** evaluations, not just finished ones.

## Changes

### `frontend/src/api.ts`
- Added `getStartTimestamp(metadata)` — returns the earliest available timestamp (init → runInferStart)
- Added `getEndTimestamp(metadata)` — returns the end timestamp for finished runs (evalInferEnd for completed, error timestamp for errored)
- Added `isFinished(metadata)` — returns `true` for completed or error status
- Added `formatDurationMs(ms)` — formats milliseconds as human-readable duration (e.g. `2h 30m`, `45s`)
- Added `getRuntime(metadata, now?)` — computes runtime:
  - **Finished runs** (completed/error): start → end timestamp
  - **Non-finished runs** (pending/running-infer/running-eval): start → current time (`now` parameter)

### `frontend/src/components/RunListView.tsx`
- Added a **Runtime** column to the runs table
- Added a 1-second interval timer that updates only when non-finished runs exist
- Finished runs show runtime in muted text
- Non-finished runs show live-updating runtime in accent color with a ⏱ indicator

### `frontend/src/api.test.ts`
- Added 28 unit tests covering all new utility functions and existing `getStageStatus`

## Testing

All 28 tests pass:
```
✓ src/api.test.ts (28 tests) 7ms
  ✓ formatDurationMs (5)
  ✓ getStartTimestamp (3)
  ✓ getEndTimestamp (4)
  ✓ isFinished (4)
  ✓ getRuntime (7)
  ✓ getStageStatus (5)
```

TypeScript build (`tsc -b && vite build`) succeeds with no errors.