### PR TITLE
feat: Add combo box to select how many days to see at once

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
-import { fetchRunList, fetchRunMetadata, parseRunSlug, getStageStatus } from './api'
-import type { RunMetadata } from './api'
+import { fetchMultiDayRunList, fetchRunMetadata, parseRunSlug, getStageStatus } from './api'
+import type { RunMetadata, DayRunGroup } from './api'
 import RunListView from './components/RunListView'
 import RunDetailView from './components/RunDetailView'
 import Header from './components/Header'
@@ -10,14 +10,16 @@ function getTodayUTC(): string {
   return now.toISOString().split('T')[0]
 }
 
-export function parseSearchParams(search: string, defaultDate: string): { date: string; run: string | null } {
+export function parseSearchParams(search: string, defaultDate: string): { date: string; run: string | null; numDays: number } {
   const params = new URLSearchParams(search)
   const date = params.get('date') || defaultDate
   const run = params.get('run') || null
-  return { date, run }
+  const numDaysParam = parseInt(params.get('days') || '1', 10)
+  const numDays = numDaysParam >= 1 && numDaysParam <= 7 ? numDaysParam : 1
+  return { date, run, numDays }
 }
 
-export function buildSearchString(date: string, run: string | null, todayDate: string): string {
+export function buildSearchString(date: string, run: string | null, todayDate: string, numDays: number = 1): string {
   const params = new URLSearchParams()
   if (date !== todayDate) {
     params.set('date', date)
@@ -25,22 +27,27 @@ export function buildSearchString(date: string, run: string | null, todayDate: s
   if (run) {
     params.set('run', run)
   }
+  if (numDays > 1) {
+    params.set('days', String(numDays))
+  }
   const qs = params.toString()
   return qs ? `?${qs}` : ''
 }
 
-function parseUrlState(): { date: string; run: string | null } {
+function parseUrlState(): { date: string; run: string | null; numDays: number } {
   return parseSearchParams(window.location.search, getTodayUTC())
 }
 
-function buildUrl(date: string, run: string | null): string {
-  const qs = buildSearchString(date, run, getTodayUTC())
+function buildUrl(date: string, run: string | null, numDays: number): string {
+  const qs = buildSearchString(date, run, getTodayUTC(), numDays)
   return qs || window.location.pathname
 }
 
 export default function App() {
   const [date, setDate] = useState(() => parseUrlState().date)
+  const [numDays, setNumDays] = useState(() => parseUrlState().numDays)
   const [runs, setRuns] = useState<string[]>([])
+  const [dayGroups, setDayGroups] = useState<DayRunGroup[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedRun, setSelectedRun] = useState<string | null>(() => parseUrlState().run)
@@ -51,16 +58,16 @@ export default function App() {
   const [runMetadataMap, setRunMetadataMap] = useState<Record<string, RunMetadata>>({})
   const [loadingMetadataList, setLoadingMetadataList] = useState(false)
 
-  // Sync URL when date or selectedRun changes (skip on initial mount)
+  // Sync URL when date, selectedRun, or numDays changes (skip on initial mount)
   const [initialized, setInitialized] = useState(false)
   useEffect(() => {
     if (!initialized) {
       setInitialized(true)
       return
     }
-    const url = buildUrl(date, selectedRun)
-    window.history.pushState({ date, run: selectedRun }, '', url)
-  }, [date, selectedRun]) // eslint-disable-line react-hooks/exhaustive-deps
+    const url = buildUrl(date, selectedRun, numDays)
+    window.history.pushState({ date, run: selectedRun, numDays }, '', url)
+  }, [date, selectedRun, numDays]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle browser back/forward navigation
   useEffect(() => {
@@ -68,6 +75,7 @@ export default function App() {
       const state = parseUrlState()
       setDate(state.date)
       setSelectedRun(state.run)
+      setNumDays(state.numDays)
       if (!state.run) {
         setRunMetadata(null)
       }
@@ -81,15 +89,18 @@ export default function App() {
     setError(null)
     setRunMetadataMap({})
     try {
-      const list = await fetchRunList(date)
-      setRuns(list)
+      const groups = await fetchMultiDayRunList(date, numDays)
+      setDayGroups(groups)
+      const allRuns = groups.flatMap(g => g.runs)
+      setRuns(allRuns)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load runs')
       setRuns([])
+      setDayGroups([])
     } finally {
       setLoading(false)
     }
-  }, [date])
+  }, [date, numDays])
 
   // Fetch metadata for all runs to show status in the list
   const loadAllMetadata = useCallback(async (runSlugs: string[]) => {
@@ -192,6 +203,8 @@ export default function App() {
         onRefresh={handleRefresh}
         selectedRun={selectedRun}
         onBack={handleBack}
+        numDays={numDays}
+        onNumDaysChange={setNumDays}
       />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
@@ -210,6 +223,7 @@ export default function App() {
             onSelectRun={handleSelectRun}
             runMetadataMap={runMetadataMap}
             loadingMetadataList={loadingMetadataList}
+            dayGroups={dayGroups}
           />
         )}
       </main>

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy } from '../api'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, getDateNDaysAgo, getDatesForRange } from '../api'
 import type { RunMetadata } from '../api'
 
 describe('getResultsUrl', () => {
@@ -161,5 +161,57 @@ describe('extractTriggeredBy', () => {
       init: { triggered_by: '' },
     })
     expect(extractTriggeredBy(metadata)).toBe('—')
+  })
+})
+
+describe('getDateNDaysAgo', () => {
+  it('returns the same date for n=0', () => {
+    expect(getDateNDaysAgo('2025-03-17', 0)).toBe('2025-03-17')
+  })
+
+  it('returns yesterday for n=1', () => {
+    expect(getDateNDaysAgo('2025-03-17', 1)).toBe('2025-03-16')
+  })
+
+  it('handles month boundary', () => {
+    expect(getDateNDaysAgo('2025-03-01', 1)).toBe('2025-02-28')
+  })
+
+  it('handles year boundary', () => {
+    expect(getDateNDaysAgo('2025-01-01', 1)).toBe('2024-12-31')
+  })
+
+  it('returns 7 days ago correctly', () => {
+    expect(getDateNDaysAgo('2025-03-17', 7)).toBe('2025-03-10')
+  })
+})
+
+describe('getDatesForRange', () => {
+  it('returns single date for numDays=1', () => {
+    expect(getDatesForRange('2025-03-17', 1)).toEqual(['2025-03-17'])
+  })
+
+  it('returns 3 dates in order (most recent first)', () => {
+    expect(getDatesForRange('2025-03-17', 3)).toEqual([
+      '2025-03-17',
+      '2025-03-16',
+      '2025-03-15',
+    ])
+  })
+
+  it('returns 7 dates for a full week', () => {
+    const dates = getDatesForRange('2025-03-17', 7)
+    expect(dates).toHaveLength(7)
+    expect(dates[0]).toBe('2025-03-17')
+    expect(dates[6]).toBe('2025-03-11')
+  })
+
+  it('handles month boundary across range', () => {
+    const dates = getDatesForRange('2025-03-02', 3)
+    expect(dates).toEqual([
+      '2025-03-02',
+      '2025-03-01',
+      '2025-02-28',
+    ])
   })
 })

--- a/frontend/src/__tests__/url-routing.test.ts
+++ b/frontend/src/__tests__/url-routing.test.ts
@@ -6,32 +6,50 @@ describe('parseSearchParams', () => {
 
   it('returns defaults when search string is empty', () => {
     const result = parseSearchParams('', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 1 })
   })
 
   it('parses date from search params', () => {
     const result = parseSearchParams('?date=2025-01-15', defaultDate)
-    expect(result).toEqual({ date: '2025-01-15', run: null })
+    expect(result).toEqual({ date: '2025-01-15', run: null, numDays: 1 })
   })
 
   it('parses run from search params', () => {
     const result = parseSearchParams('?run=swebench/model/123', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123' })
+    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123', numDays: 1 })
   })
 
   it('parses both date and run from search params', () => {
     const result = parseSearchParams('?date=2025-02-20&run=gaia/litellm_proxy-gpt4/456', defaultDate)
-    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456' })
+    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456', numDays: 1 })
   })
 
   it('handles URL-encoded run slugs with slashes', () => {
     const result = parseSearchParams('?run=bench%2Fmodel%2Fjob', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job' })
+    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job', numDays: 1 })
   })
 
   it('uses default date when date param is missing', () => {
     const result = parseSearchParams('?run=test/run/1', '2025-12-31')
-    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1' })
+    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1', numDays: 1 })
+  })
+
+  it('parses days param', () => {
+    const result = parseSearchParams('?days=3', defaultDate)
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3 })
+  })
+
+  it('clamps days param to valid range (1-7)', () => {
+    expect(parseSearchParams('?days=0', defaultDate).numDays).toBe(1)
+    expect(parseSearchParams('?days=8', defaultDate).numDays).toBe(1)
+    expect(parseSearchParams('?days=-1', defaultDate).numDays).toBe(1)
+    expect(parseSearchParams('?days=abc', defaultDate).numDays).toBe(1)
+    expect(parseSearchParams('?days=7', defaultDate).numDays).toBe(7)
+  })
+
+  it('parses date, run, and days together', () => {
+    const result = parseSearchParams('?date=2025-02-20&run=gaia/model/1&days=5', defaultDate)
+    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/model/1', numDays: 5 })
   })
 })
 
@@ -62,6 +80,21 @@ describe('buildSearchString', () => {
     const result = buildSearchString(today, 'bench/model/job', today)
     expect(result).toBe('?run=bench%2Fmodel%2Fjob')
   })
+
+  it('omits days param when numDays is 1 (default)', () => {
+    const result = buildSearchString(today, null, today, 1)
+    expect(result).toBe('')
+  })
+
+  it('includes days param when numDays > 1', () => {
+    const result = buildSearchString(today, null, today, 3)
+    expect(result).toBe('?days=3')
+  })
+
+  it('includes days along with date and run', () => {
+    const result = buildSearchString('2025-02-20', 'gaia/model/1', today, 5)
+    expect(result).toBe('?date=2025-02-20&run=gaia%2Fmodel%2F1&days=5')
+  })
 })
 
 describe('round-trip: buildSearchString -> parseSearchParams', () => {
@@ -72,26 +105,41 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     const run = 'swebench/litellm_proxy-claude/789'
     const qs = buildSearchString(date, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run })
+    expect(parsed).toEqual({ date, run, numDays: 1 })
   })
 
   it('round-trips a run selection with today date', () => {
     const run = 'gaia/model/42'
     const qs = buildSearchString(today, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run })
+    expect(parsed).toEqual({ date: today, run, numDays: 1 })
   })
 
   it('round-trips list view with non-today date', () => {
     const date = '2025-06-15'
     const qs = buildSearchString(date, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run: null })
+    expect(parsed).toEqual({ date, run: null, numDays: 1 })
   })
 
   it('round-trips list view with today date', () => {
     const qs = buildSearchString(today, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 1 })
+  })
+
+  it('round-trips with numDays > 1', () => {
+    const date = '2025-02-20'
+    const run = 'swebench/model/123'
+    const numDays = 5
+    const qs = buildSearchString(date, run, today, numDays)
+    const parsed = parseSearchParams(qs, today)
+    expect(parsed).toEqual({ date, run, numDays })
+  })
+
+  it('round-trips with numDays = 1 (default omitted)', () => {
+    const qs = buildSearchString(today, null, today, 1)
+    const parsed = parseSearchParams(qs, today)
+    expect(parsed).toEqual({ date: today, run: null, numDays: 1 })
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,40 @@ export async function fetchRunList(date: string): Promise<string[]> {
     .reverse()
 }
 
+export function getDateNDaysAgo(baseDate: string, n: number): string {
+  const d = new Date(baseDate + 'T00:00:00Z')
+  d.setUTCDate(d.getUTCDate() - n)
+  return d.toISOString().split('T')[0]
+}
+
+export function getDatesForRange(baseDate: string, numDays: number): string[] {
+  const dates: string[] = []
+  for (let i = 0; i < numDays; i++) {
+    dates.push(getDateNDaysAgo(baseDate, i))
+  }
+  return dates
+}
+
+export interface DayRunGroup {
+  date: string
+  runs: string[]
+}
+
+export async function fetchMultiDayRunList(baseDate: string, numDays: number): Promise<DayRunGroup[]> {
+  const dates = getDatesForRange(baseDate, numDays)
+  const results = await Promise.all(
+    dates.map(async (date) => {
+      try {
+        const runs = await fetchRunList(date)
+        return { date, runs }
+      } catch {
+        return { date, runs: [] }
+      }
+    })
+  )
+  return results
+}
+
 export interface RunMetadata {
   init: Record<string, unknown> | null
   params: Record<string, unknown> | null

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,9 +4,11 @@ interface HeaderProps {
   onRefresh: () => void
   selectedRun: string | null
   onBack: () => void
+  numDays: number
+  onNumDaysChange: (days: number) => void
 }
 
-export default function Header({ date, onDateChange, onRefresh, selectedRun, onBack }: HeaderProps) {
+export default function Header({ date, onDateChange, onRefresh, selectedRun, onBack, numDays, onNumDaysChange }: HeaderProps) {
   const handlePrevDay = () => {
     const d = new Date(date + 'T00:00:00Z')
     d.setUTCDate(d.getUTCDate() - 1)
@@ -46,7 +48,7 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
             </div>
           </div>
 
-          {/* Center: Date Navigation */}
+          {/* Center: Date Navigation + Days Selector */}
           {!selectedRun && (
             <div className="flex items-center gap-2">
               <button
@@ -73,6 +75,18 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
               </button>
+              <select
+                value={numDays}
+                onChange={(e) => onNumDaysChange(parseInt(e.target.value, 10))}
+                className="bg-oh-bg border border-oh-border rounded-lg px-3 py-1.5 text-sm text-oh-text focus:outline-none focus:border-oh-primary transition-colors ml-2"
+                title="Number of days to display"
+              >
+                {[1, 2, 3, 4, 5, 6, 7].map(n => (
+                  <option key={n} value={n}>
+                    {n} {n === 1 ? 'day' : 'days'}
+                  </option>
+                ))}
+              </select>
             </div>
           )}
 

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo } from 'react'
-import type { RunMetadata } from '../api'
+import React, { useState, useEffect, useMemo } from 'react'
+import type { RunMetadata, DayRunGroup } from '../api'
 import { getStageStatus, getRuntime, isFinished, extractTriggeredBy } from '../api'
 
 interface RunInfo {
@@ -16,6 +16,7 @@ interface RunListViewProps {
   onSelectRun: (slug: string) => void
   runMetadataMap: Record<string, RunMetadata>
   loadingMetadataList: boolean
+  dayGroups: DayRunGroup[]
 }
 
 type StatusType = 'pending' | 'running-infer' | 'running-eval' | 'completed' | 'error'
@@ -83,7 +84,19 @@ function BenchmarkBadge({ name }: { name: string }) {
 }
 
 
-export default function RunListView({ runs, loading, error, onSelectRun, runMetadataMap, loadingMetadataList }: RunListViewProps) {
+export default function RunListView({ runs, loading, error, onSelectRun, runMetadataMap, loadingMetadataList, dayGroups }: RunListViewProps) {
+  const showMultipleDays = dayGroups.length > 1
+
+  // Build a slug-to-date mapping for date grouping
+  const slugToDate = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const group of dayGroups) {
+      for (const slug of group.runs) {
+        map[slug] = group.date
+      }
+    }
+    return map
+  }, [dayGroups])
   const [filterBenchmark, setFilterBenchmark] = useState<string>('all')
   const [filterStatus, setFilterStatus] = useState<string>('all')
   const [filterText, setFilterText] = useState('')
@@ -274,45 +287,61 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
                   </td>
                 </tr>
               ) : (
-                filteredRuns.map(run => (
-                  <tr
-                    key={run.slug}
-                    onClick={() => onSelectRun(run.slug)}
-                    className="hover:bg-oh-surface-hover cursor-pointer transition-colors group"
-                  >
-                    <td className="px-4 py-3 whitespace-nowrap">
-                      <StatusBadge status={run.status} />
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
-                      <BenchmarkBadge name={run.benchmark} />
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="text-sm font-medium text-oh-text group-hover:text-oh-primary transition-colors">
-                        {run.model || run.slug}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
-                      <span className="text-sm text-oh-text-muted font-mono">
-                        #{run.jobId}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
-                      {run.runtime ? (
-                        <span className={`text-sm font-mono ${run.runFinished ? 'text-oh-text-muted' : 'text-oh-primary'}`}>
-                          {run.runtime}
-                          {!run.runFinished && <span className="ml-1 text-xs opacity-60">⏱</span>}
-                        </span>
-                      ) : (
-                        <span className="text-sm text-oh-text-muted">—</span>
+                filteredRuns.map((run, index) => {
+                  const runDate = slugToDate[run.slug]
+                  const prevRunDate = index > 0 ? slugToDate[filteredRuns[index - 1].slug] : null
+                  const showDateHeader = showMultipleDays && runDate && runDate !== prevRunDate
+
+                  return (
+                    <React.Fragment key={run.slug}>
+                      {showDateHeader && (
+                        <tr className="bg-oh-bg">
+                          <td colSpan={6} className="px-4 py-2">
+                            <span className="text-xs font-semibold text-oh-text-muted uppercase tracking-wider">
+                              {runDate}
+                            </span>
+                          </td>
+                        </tr>
                       )}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
-                      <span className="text-sm text-oh-text-muted">
-                        {run.triggeredBy}
-                      </span>
-                    </td>
-                  </tr>
-                ))
+                      <tr
+                        onClick={() => onSelectRun(run.slug)}
+                        className="hover:bg-oh-surface-hover cursor-pointer transition-colors group"
+                      >
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <StatusBadge status={run.status} />
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <BenchmarkBadge name={run.benchmark} />
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className="text-sm font-medium text-oh-text group-hover:text-oh-primary transition-colors">
+                            {run.model || run.slug}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className="text-sm text-oh-text-muted font-mono">
+                            #{run.jobId}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          {run.runtime ? (
+                            <span className={`text-sm font-mono ${run.runFinished ? 'text-oh-text-muted' : 'text-oh-primary'}`}>
+                              {run.runtime}
+                              {!run.runFinished && <span className="ml-1 text-xs opacity-60">⏱</span>}
+                            </span>
+                          ) : (
+                            <span className="text-sm text-oh-text-muted">—</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className="text-sm text-oh-text-muted">
+                            {run.triggeredBy}
+                          </span>
+                        </td>
+                      </tr>
+                    </React.Fragment>
+                  )
+                })
               )}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary

Adds a combo box (dropdown) in the header to select how many days of runs to display at once, from 1 to 7 days.

Fixes #2

## Changes

### New Features
- **Days selector dropdown** in the Header component, positioned next to the date navigation controls
- **Multi-day run fetching**: When selecting more than 1 day, runs are fetched for all dates in the range (e.g., selecting 3 days shows today, yesterday, and the day before)
- **Date section headers**: When viewing multiple days, date headers appear in the run list to group runs by their date, with the most recent date on top
- **URL persistence**: The `days` parameter is stored in the URL query string (e.g., `?days=3`), omitted when equal to the default of 1

### API Layer (`api.ts`)
- `getDateNDaysAgo(baseDate, n)` — computes a date N days before the base date
- `getDatesForRange(baseDate, numDays)` — returns an array of date strings (most recent first)
- `fetchMultiDayRunList(baseDate, numDays)` — fetches run lists for all dates in the range, returning `DayRunGroup[]`

### Behavior
- **Default is 1 day** — same behavior as before, fully backward compatible
- Selecting a different number of days immediately fetches and displays runs for all dates in the range
- Browser back/forward navigation preserves the days selection
- The combo box is only visible in the list view (hidden when viewing a run detail)

## Tests
- Updated all existing URL routing tests to include the new `numDays` field
- Added new tests for `parseSearchParams` with `days` parameter (including validation/clamping)
- Added new tests for `buildSearchString` with `numDays`
- Added new round-trip tests for `numDays`
- Added unit tests for `getDateNDaysAgo` (including month/year boundaries)
- Added unit tests for `getDatesForRange`

All 77 tests pass.