### PR TITLE
feat: show triggered by and runtime in RunDetailView header

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import RunDetailView from '../components/RunDetailView'
+import type { RunMetadata } from '../api'
+
+function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
+  return {
+    init: null,
+    params: null,
+    error: null,
+    runInferStart: null,
+    runInferEnd: null,
+    evalInferStart: null,
+    evalInferEnd: null,
+    ...overrides,
+  }
+}
+
+describe('RunDetailView', () => {
+  const defaultSlug = 'swebench/litellm_proxy-claude-sonnet/123'
+
+  it('shows triggered by from metadata', () => {
+    const metadata = makeMetadata({
+      params: { triggered_by: 'juanmichelini', timestamp: '2025-03-15T10:00:00Z' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('triggered-by')
+    expect(el.textContent).toContain('juanmichelini')
+  })
+
+  it('shows dash for triggered by when metadata has no trigger info', () => {
+    const metadata = makeMetadata({
+      params: { llm_config: 'gpt-5' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('triggered-by')
+    expect(el.textContent).toContain('—')
+  })
+
+  it('shows runtime for a completed run', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      evalInferEnd: { timestamp: '2025-03-15T11:30:00Z' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="completed" />
+    )
+    const el = screen.getByTestId('runtime')
+    expect(el.textContent).toContain('1h 30m')
+  })
+
+  it('shows dash for runtime when no timestamps are available', () => {
+    const metadata = makeMetadata()
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('runtime')
+    expect(el.textContent).toContain('—')
+  })
+
+  it('shows dash for triggered by and runtime when metadata is null', () => {
+    render(
+      <RunDetailView slug={defaultSlug} metadata={null} loading={false} status="pending" />
+    )
+    const triggeredByEl = screen.getByTestId('triggered-by')
+    expect(triggeredByEl.textContent).toContain('—')
+    const runtimeEl = screen.getByTestId('runtime')
+    expect(runtimeEl.textContent).toContain('—')
+  })
+
+  it('shows timer icon for running (non-finished) run with runtime', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:01:00Z' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="running-infer" />
+    )
+    const el = screen.getByTestId('runtime')
+    expect(el.textContent).toContain('⏱')
+  })
+
+  it('does not show timer icon for completed runs', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      evalInferEnd: { timestamp: '2025-03-15T10:45:00Z' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="completed" />
+    )
+    const el = screen.getByTestId('runtime')
+    expect(el.textContent).not.toContain('⏱')
+  })
+})

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -1,4 +1,4 @@
-import { parseRunSlug } from '../api'
+import { parseRunSlug, extractTriggeredBy, getRuntime, isFinished } from '../api'
 import type { RunMetadata } from '../api'
 import StatusTimeline from './StatusTimeline'
 import JsonCard from './JsonCard'
@@ -28,6 +28,10 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
     )
   }
 
+  const triggeredBy = metadata ? extractTriggeredBy(metadata) : '—'
+  const runFinished = metadata ? isFinished(metadata) : true
+  const runtime = metadata ? getRuntime(metadata) : null
+
   return (
     <div className="space-y-6">
       {/* Run Header */}
@@ -39,6 +43,22 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
               <span className="font-medium">{parsed.benchmark}</span>
               {parsed.jobId && <span> · Job #{parsed.jobId}</span>}
             </p>
+            <div className="flex items-center gap-4 mt-2 text-sm text-oh-text-muted">
+              <span data-testid="triggered-by">
+                <span className="font-medium">Triggered by:</span> {triggeredBy}
+              </span>
+              <span data-testid="runtime">
+                <span className="font-medium">Runtime:</span>{' '}
+                {runtime ? (
+                  <span className={`font-mono ${runFinished ? '' : 'text-oh-primary'}`}>
+                    {runtime}
+                    {!runFinished && <span className="ml-1 text-xs opacity-60">⏱</span>}
+                  </span>
+                ) : (
+                  '—'
+                )}
+              </span>
+            </div>
           </div>
           <StatusBadge status={status} />
         </div>


### PR DESCRIPTION
## Summary

Fixes #26

Displays the **"Triggered by"** and **"Runtime"** fields in the detail page header section, so the same data shown in the list view table rows is visible at the top of the run detail view.

## Changes

- **`RunDetailView.tsx`**: Added `extractTriggeredBy`, `getRuntime`, and `isFinished` imports from the API module. Computed and rendered triggered by and runtime in the header section beneath the benchmark/job ID line.
  - Shows the triggering user (or "—" if unavailable)
  - Shows runtime with a timer icon (⏱) for in-progress runs, or a static duration for finished runs
- **`RunDetailView.test.tsx`**: Added 7 test cases covering:
  - Triggered by from metadata
  - Dash fallback when no trigger info exists
  - Runtime display for completed runs
  - Dash fallback when no timestamps are available
  - Null metadata handling
  - Timer icon for running (non-finished) runs
  - No timer icon for completed runs

## Testing

All 86 tests pass (including 7 new ones). TypeScript build succeeds.