### PR TITLE
fix: change default number of days from 1 to 2

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,12 +14,12 @@ export function parseSearchParams(search: string, defaultDate: string): { date: 
   const params = new URLSearchParams(search)
   const date = params.get('date') || defaultDate
   const run = params.get('run') || null
-  const numDaysParam = parseInt(params.get('days') || '1', 10)
-  const numDays = numDaysParam >= 1 && numDaysParam <= 7 ? numDaysParam : 1
+  const numDaysParam = parseInt(params.get('days') || '2', 10)
+  const numDays = numDaysParam >= 1 && numDaysParam <= 7 ? numDaysParam : 2
   return { date, run, numDays }
 }
 
-export function buildSearchString(date: string, run: string | null, todayDate: string, numDays: number = 1): string {
+export function buildSearchString(date: string, run: string | null, todayDate: string, numDays: number = 2): string {
   const params = new URLSearchParams()
   if (date !== todayDate) {
     params.set('date', date)
@@ -27,7 +27,7 @@ export function buildSearchString(date: string, run: string | null, todayDate: s
   if (run) {
     params.set('run', run)
   }
-  if (numDays > 1) {
+  if (numDays !== 2) {
     params.set('days', String(numDays))
   }
   const qs = params.toString()

--- a/frontend/src/__tests__/url-routing.test.ts
+++ b/frontend/src/__tests__/url-routing.test.ts
@@ -6,32 +6,32 @@ describe('parseSearchParams', () => {
 
   it('returns defaults when search string is empty', () => {
     const result = parseSearchParams('', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 1 })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 2 })
   })
 
   it('parses date from search params', () => {
     const result = parseSearchParams('?date=2025-01-15', defaultDate)
-    expect(result).toEqual({ date: '2025-01-15', run: null, numDays: 1 })
+    expect(result).toEqual({ date: '2025-01-15', run: null, numDays: 2 })
   })
 
   it('parses run from search params', () => {
     const result = parseSearchParams('?run=swebench/model/123', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123', numDays: 1 })
+    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123', numDays: 2 })
   })
 
   it('parses both date and run from search params', () => {
     const result = parseSearchParams('?date=2025-02-20&run=gaia/litellm_proxy-gpt4/456', defaultDate)
-    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456', numDays: 1 })
+    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456', numDays: 2 })
   })
 
   it('handles URL-encoded run slugs with slashes', () => {
     const result = parseSearchParams('?run=bench%2Fmodel%2Fjob', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job', numDays: 1 })
+    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job', numDays: 2 })
   })
 
   it('uses default date when date param is missing', () => {
     const result = parseSearchParams('?run=test/run/1', '2025-12-31')
-    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1', numDays: 1 })
+    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1', numDays: 2 })
   })
 
   it('parses days param', () => {
@@ -40,10 +40,10 @@ describe('parseSearchParams', () => {
   })
 
   it('clamps days param to valid range (1-7)', () => {
-    expect(parseSearchParams('?days=0', defaultDate).numDays).toBe(1)
-    expect(parseSearchParams('?days=8', defaultDate).numDays).toBe(1)
-    expect(parseSearchParams('?days=-1', defaultDate).numDays).toBe(1)
-    expect(parseSearchParams('?days=abc', defaultDate).numDays).toBe(1)
+    expect(parseSearchParams('?days=0', defaultDate).numDays).toBe(2)
+    expect(parseSearchParams('?days=8', defaultDate).numDays).toBe(2)
+    expect(parseSearchParams('?days=-1', defaultDate).numDays).toBe(2)
+    expect(parseSearchParams('?days=abc', defaultDate).numDays).toBe(2)
     expect(parseSearchParams('?days=7', defaultDate).numDays).toBe(7)
   })
 
@@ -81,14 +81,19 @@ describe('buildSearchString', () => {
     expect(result).toBe('?run=bench%2Fmodel%2Fjob')
   })
 
-  it('omits days param when numDays is 1 (default)', () => {
-    const result = buildSearchString(today, null, today, 1)
+  it('omits days param when numDays is 2 (default)', () => {
+    const result = buildSearchString(today, null, today, 2)
     expect(result).toBe('')
   })
 
-  it('includes days param when numDays > 1', () => {
+  it('includes days param when numDays is not the default', () => {
     const result = buildSearchString(today, null, today, 3)
     expect(result).toBe('?days=3')
+  })
+
+  it('includes days param when numDays is 1', () => {
+    const result = buildSearchString(today, null, today, 1)
+    expect(result).toBe('?days=1')
   })
 
   it('includes days along with date and run', () => {
@@ -105,30 +110,30 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     const run = 'swebench/litellm_proxy-claude/789'
     const qs = buildSearchString(date, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run, numDays: 1 })
+    expect(parsed).toEqual({ date, run, numDays: 2 })
   })
 
   it('round-trips a run selection with today date', () => {
     const run = 'gaia/model/42'
     const qs = buildSearchString(today, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run, numDays: 1 })
+    expect(parsed).toEqual({ date: today, run, numDays: 2 })
   })
 
   it('round-trips list view with non-today date', () => {
     const date = '2025-06-15'
     const qs = buildSearchString(date, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run: null, numDays: 1 })
+    expect(parsed).toEqual({ date, run: null, numDays: 2 })
   })
 
   it('round-trips list view with today date', () => {
     const qs = buildSearchString(today, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 1 })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 2 })
   })
 
-  it('round-trips with numDays > 1', () => {
+  it('round-trips with numDays > 2', () => {
     const date = '2025-02-20'
     const run = 'swebench/model/123'
     const numDays = 5
@@ -137,7 +142,13 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     expect(parsed).toEqual({ date, run, numDays })
   })
 
-  it('round-trips with numDays = 1 (default omitted)', () => {
+  it('round-trips with numDays = 2 (default omitted)', () => {
+    const qs = buildSearchString(today, null, today, 2)
+    const parsed = parseSearchParams(qs, today)
+    expect(parsed).toEqual({ date: today, run: null, numDays: 2 })
+  })
+
+  it('round-trips with numDays = 1', () => {
     const qs = buildSearchString(today, null, today, 1)
     const parsed = parseSearchParams(qs, today)
     expect(parsed).toEqual({ date: today, run: null, numDays: 1 })


### PR DESCRIPTION
## Summary

Changes the default number of days displayed from 1 to 2, as requested in #30.

## Changes

- **`frontend/src/App.tsx`**: Updated default `numDays` from `1` to `2` in `parseSearchParams`, `buildSearchString`, and the URL serialization logic
- **`frontend/src/__tests__/url-routing.test.ts`**: Updated test expectations to reflect the new default of 2 days

Fixes #30