### PR TITLE
fix: move error section before Pipeline Progress

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -95,4 +95,54 @@ describe('RunDetailView', () => {
     const el = screen.getByTestId('runtime')
     expect(el.textContent).not.toContain('⏱')
   })
+
+  it('renders error section before pipeline progress and after run header', () => {
+    const metadata = makeMetadata({
+      error: { message: 'Something went wrong', code: 'FAIL' },
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:01:00Z' },
+    })
+    const { container } = render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="error" />
+    )
+
+    // Error section should be present
+    const errorSection = screen.getByTestId('error-section')
+    expect(errorSection).toBeTruthy()
+    expect(errorSection.textContent).toContain('Something went wrong')
+
+    // Verify ordering: error section appears before the StatusTimeline
+    // and after the run header in the DOM
+    const topLevelChildren = container.querySelector('.space-y-6')!.children
+    const childArray = Array.from(topLevelChildren)
+
+    // Find indices of key sections
+    const headerIdx = childArray.findIndex(el =>
+      el.querySelector('h2')?.textContent?.includes('claude-sonnet')
+    )
+    const errorIdx = childArray.findIndex(el =>
+      el.getAttribute('data-testid') === 'error-section'
+    )
+    const timelineIdx = childArray.findIndex(el =>
+      el.textContent?.includes('Pipeline Progress')
+    )
+
+    expect(headerIdx).toBeGreaterThanOrEqual(0)
+    expect(errorIdx).toBeGreaterThanOrEqual(0)
+    expect(timelineIdx).toBeGreaterThanOrEqual(0)
+
+    // Error should come after header and before timeline
+    expect(errorIdx).toBeGreaterThan(headerIdx)
+    expect(errorIdx).toBeLessThan(timelineIdx)
+  })
+
+  it('does not render error section when there is no error', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    expect(screen.queryByTestId('error-section')).toBeNull()
+  })
 })

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -64,6 +64,13 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
         </div>
       </div>
 
+      {/* Error Section */}
+      {metadata?.error && (
+        <div data-testid="error-section">
+          <JsonCard title="Error" data={metadata.error} icon="❌" isError />
+        </div>
+      )}
+
       {/* Completed Run Results */}
       {status === 'completed' && <CompletedRunResults slug={slug} />}
 
@@ -78,11 +85,6 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
         <JsonCard title="Run Infer End" data={metadata?.runInferEnd} icon="⏹️" />
         <JsonCard title="Eval Infer Start" data={metadata?.evalInferStart} icon="🔍" />
         <JsonCard title="Eval Infer End" data={metadata?.evalInferEnd} icon="✅" />
-        {metadata?.error && (
-          <div className="lg:col-span-2">
-            <JsonCard title="Error" data={metadata.error} icon="❌" isError />
-          </div>
-        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Fixes #27

Moves the Error section from the bottom of the Metadata Cards grid to appear right after the Run Header (job id section) and before Pipeline Progress (StatusTimeline).

## Changes

- **`frontend/src/components/RunDetailView.tsx`**: Extracted the error `JsonCard` from the metadata grid and placed it as a standalone section between the Run Header and Completed Run Results / Status Timeline.
- **`frontend/src/__tests__/RunDetailView.test.tsx`**: Added two new tests:
  - Verifies the error section renders between the Run Header and Pipeline Progress in the DOM order.
  - Verifies the error section is not rendered when there is no error.

## Before

1. Run Header
2. Completed Run Results
3. Pipeline Progress (StatusTimeline)
4. Metadata Cards (including Error at the bottom)

## After

1. Run Header
2. **Error Section** (if present)
3. Completed Run Results
4. Pipeline Progress (StatusTimeline)
5. Metadata Cards (without Error)