### PR TITLE
Replace Init stage with Building Images in Pipeline Progress

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -145,4 +145,37 @@ describe('RunDetailView', () => {
     )
     expect(screen.queryByTestId('error-section')).toBeNull()
   })
+
+  it('shows Building Images stage in Pipeline Progress instead of Init', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:06:00Z' },
+    })
+    const { container } = render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="running-infer" />
+    )
+    // Find the Pipeline Progress section specifically
+    const pipelineHeading = Array.from(container.querySelectorAll('h3')).find(
+      el => el.textContent === 'Pipeline Progress'
+    )
+    expect(pipelineHeading).toBeTruthy()
+    const pipelineSection = pipelineHeading!.parentElement!
+    // Stage labels use specific classes; select only the label elements
+    const stageLabels = Array.from(pipelineSection.querySelectorAll('p.text-xs.font-medium'))
+      .map(p => p.textContent)
+    expect(stageLabels).toContain('Building Images')
+    expect(stageLabels).not.toContain('Init')
+  })
+
+  it('shows Building Images badge for building status', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="building" />
+    )
+    const badges = screen.getAllByText('Building Images')
+    expect(badges.length).toBeGreaterThanOrEqual(1)
+  })
 })

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -245,4 +245,14 @@ describe('getStageStatus', () => {
     const m = makeMetadata({ init: ts('2025-01-01T10:00:00Z') })
     expect(getStageStatus(m)).toBe('pending')
   })
+
+  it('returns building when only params exists (no init yet)', () => {
+    const m = makeMetadata({ params: ts('2025-01-01T10:00:00Z') })
+    expect(getStageStatus(m)).toBe('building')
+  })
+
+  it('returns pending when nothing exists', () => {
+    const m = makeMetadata()
+    expect(getStageStatus(m)).toBe('pending')
+  })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -108,13 +108,14 @@ export function parseRunSlug(slug: string) {
   return { benchmark: slug, model: '', jobId: '' }
 }
 
-export function getStageStatus(metadata: RunMetadata): 'pending' | 'running-infer' | 'running-eval' | 'completed' | 'error' {
+export function getStageStatus(metadata: RunMetadata): 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' {
   if (metadata.error) return 'error'
   if (metadata.evalInferEnd) return 'completed'
   if (metadata.evalInferStart) return 'running-eval'
   if (metadata.runInferEnd) return 'running-eval'
   if (metadata.runInferStart) return 'running-infer'
   if (metadata.init) return 'pending'
+  if (metadata.params) return 'building'
   return 'pending'
 }
 

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -8,7 +8,7 @@ interface RunDetailViewProps {
   slug: string
   metadata: RunMetadata | null
   loading: boolean
-  status: 'pending' | 'running-infer' | 'running-eval' | 'completed' | 'error'
+  status: 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error'
 }
 
 export default function RunDetailView({ slug, metadata, loading, status }: RunDetailViewProps) {
@@ -93,6 +93,7 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
     'pending': 'bg-gray-500/20 text-gray-400 border-gray-500/30',
+    'building': 'bg-violet-500/20 text-violet-400 border-violet-500/30',
     'running-infer': 'bg-oh-primary/20 text-oh-primary border-oh-primary/30',
     'running-eval': 'bg-oh-warning/20 text-oh-warning border-oh-warning/30',
     'completed': 'bg-oh-success/20 text-oh-success border-oh-success/30',
@@ -101,6 +102,7 @@ function StatusBadge({ status }: { status: string }) {
 
   const labels: Record<string, string> = {
     'pending': 'Pending',
+    'building': 'Building Images',
     'running-infer': 'Running Inference',
     'running-eval': 'Running Evaluation',
     'completed': 'Completed',
@@ -109,7 +111,7 @@ function StatusBadge({ status }: { status: string }) {
 
   return (
     <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium border ${styles[status] || styles['pending']}`}>
-      {(status === 'running-infer' || status === 'running-eval') && (
+      {(status === 'building' || status === 'running-infer' || status === 'running-eval') && (
         <span className="relative flex h-2 w-2">
           <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-current" />
           <span className="relative inline-flex rounded-full h-2 w-2 bg-current" />

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -19,12 +19,17 @@ interface RunListViewProps {
   dayGroups: DayRunGroup[]
 }
 
-type StatusType = 'pending' | 'running-infer' | 'running-eval' | 'completed' | 'error'
+type StatusType = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error'
 
 const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?: string }> = {
   pending: {
     label: 'Pending',
     className: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
+  },
+  building: {
+    label: 'Building Images',
+    className: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
+    dot: 'bg-violet-400 animate-pulse',
   },
   'running-infer': {
     label: 'Running Inference',

--- a/frontend/src/components/StatusTimeline.tsx
+++ b/frontend/src/components/StatusTimeline.tsx
@@ -11,7 +11,7 @@ interface Stage {
 }
 
 const STAGES: Stage[] = [
-  { label: 'Init', startKey: 'init' },
+  { label: 'Building Images', startKey: 'params', endKey: 'init' },
   { label: 'Run Inference', startKey: 'runInferStart', endKey: 'runInferEnd' },
   { label: 'Run Evaluation', startKey: 'evalInferStart', endKey: 'evalInferEnd' },
 ]


### PR DESCRIPTION
## Summary

Fixes #29

Replaces the "Init" stage with a "Building Images" stage in the Pipeline Progress timeline. The Building Images stage shows duration from `params.json` timestamp (start) to `init.json` timestamp (end), giving visibility into image build time.

## Changes

### Pipeline Progress (StatusTimeline)
- Renamed "Init" stage to "Building Images"
- Changed from a point-in-time marker (`startKey: 'init'`) to a duration stage (`startKey: 'params'`, `endKey: 'init'`)
- The 3 stages are now: **Building Images** → **Run Inference** → **Run Evaluation**

### New "building" status
- Added `'building'` return value to `getStageStatus()` for when only `params` exists (no `init` yet, images are being built)
- Added building status badge styling (violet, with pulsing dot) to both `RunListView` and `RunDetailView`

### Tests
- Added test verifying "Building Images" appears in Pipeline Progress instead of "Init"
- Added test for building status badge rendering
- Added `getStageStatus` tests for `'building'` (only params) and `'pending'` (nothing) states