### PR TITLE
feat: add trigger reason to main table and detail page top section

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -62,6 +62,36 @@ describe('RunDetailView', () => {
     expect(el.textContent).toContain('—')
   })
 
+  it('shows trigger reason from metadata', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 'testing SDK: fix/issue-2375', triggered_by: 'user1', timestamp: '2025-03-15T10:00:00Z' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('trigger-reason')
+    expect(el.textContent).toContain('testing SDK: fix/issue-2375')
+  })
+
+  it('shows dash for trigger reason when metadata has no reason info', () => {
+    const metadata = makeMetadata({
+      params: { llm_config: 'gpt-5' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('trigger-reason')
+    expect(el.textContent).toContain('—')
+  })
+
+  it('shows dash for trigger reason when metadata is null', () => {
+    render(
+      <RunDetailView slug={defaultSlug} metadata={null} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('trigger-reason')
+    expect(el.textContent).toContain('—')
+  })
+
   it('shows dash for triggered by and runtime when metadata is null', () => {
     render(
       <RunDetailView slug={defaultSlug} metadata={null} loading={false} status="pending" />

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy, getDateNDaysAgo, getDatesForRange } from '../api'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange } from '../api'
 import type { RunMetadata } from '../api'
 
 describe('getResultsUrl', () => {
@@ -161,6 +161,74 @@ describe('extractTriggeredBy', () => {
       init: { triggered_by: '' },
     })
     expect(extractTriggeredBy(metadata)).toBe('—')
+  })
+})
+
+describe('extractTriggerReason', () => {
+  it('returns dash when metadata is undefined', () => {
+    expect(extractTriggerReason(undefined)).toBe('—')
+  })
+
+  it('returns dash when both init and params are null', () => {
+    expect(extractTriggerReason(makeMetadata())).toBe('—')
+  })
+
+  it('extracts trigger_reason from params.json', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 'testing SDK: fix/issue-2375', triggered_by: 'user1' },
+    })
+    expect(extractTriggerReason(metadata)).toBe('testing SDK: fix/issue-2375')
+  })
+
+  it('extracts trigger_reason from init.json as fallback', () => {
+    const metadata = makeMetadata({
+      init: { trigger_reason: 'scheduled run' },
+    })
+    expect(extractTriggerReason(metadata)).toBe('scheduled run')
+  })
+
+  it('prefers params over init when both have trigger_reason', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 'from-params' },
+      init: { trigger_reason: 'from-init' },
+    })
+    expect(extractTriggerReason(metadata)).toBe('from-params')
+  })
+
+  it('falls back to init when params has no reason keys', () => {
+    const metadata = makeMetadata({
+      params: { llm_config: 'gpt-5' },
+      init: { trigger_reason: 'nightly' },
+    })
+    expect(extractTriggerReason(metadata)).toBe('nightly')
+  })
+
+  it('recognizes alternative reason keys like event_name and event_type', () => {
+    expect(extractTriggerReason(makeMetadata({ params: { event_name: 'workflow_dispatch' } }))).toBe('workflow_dispatch')
+    expect(extractTriggerReason(makeMetadata({ init: { event_type: 'push' } }))).toBe('push')
+  })
+
+  it('ignores non-string reason values', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 123 },
+      init: { trigger_reason: 'fallback-reason' },
+    })
+    expect(extractTriggerReason(metadata)).toBe('fallback-reason')
+  })
+
+  it('returns dash when trigger_reason is null', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: null },
+    })
+    expect(extractTriggerReason(metadata)).toBe('—')
+  })
+
+  it('returns dash when reason keys exist but are empty strings', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: '' },
+      init: { trigger_reason: '' },
+    })
+    expect(extractTriggerReason(metadata)).toBe('—')
   })
 })
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -235,6 +235,18 @@ export function extractTriggeredBy(metadata: RunMetadata | undefined): string {
   return '—'
 }
 
+export function extractTriggerReason(metadata: RunMetadata | undefined): string {
+  if (!metadata) return '—'
+  const REASON_KEYS = ['trigger_reason', 'event_name', 'event_type']
+  for (const source of [metadata.params, metadata.init]) {
+    if (!source) continue
+    for (const key of REASON_KEYS) {
+      if (source[key] && typeof source[key] === 'string') return source[key] as string
+    }
+  }
+  return '—'
+}
+
 export function getRuntime(metadata: RunMetadata, now: number = Date.now()): string | null {
   const start = getStartTimestamp(metadata)
   if (start === null) return null

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -1,4 +1,4 @@
-import { parseRunSlug, extractTriggeredBy, getRuntime, isFinished } from '../api'
+import { parseRunSlug, extractTriggeredBy, extractTriggerReason, getRuntime, isFinished } from '../api'
 import type { RunMetadata } from '../api'
 import StatusTimeline from './StatusTimeline'
 import JsonCard from './JsonCard'
@@ -29,6 +29,7 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
   }
 
   const triggeredBy = metadata ? extractTriggeredBy(metadata) : '—'
+  const triggerReason = metadata ? extractTriggerReason(metadata) : '—'
   const runFinished = metadata ? isFinished(metadata) : true
   const runtime = metadata ? getRuntime(metadata) : null
 
@@ -43,7 +44,10 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
               <span className="font-medium">{parsed.benchmark}</span>
               {parsed.jobId && <span> · Job #{parsed.jobId}</span>}
             </p>
-            <div className="flex items-center gap-4 mt-2 text-sm text-oh-text-muted">
+            <div className="flex items-center gap-4 mt-2 text-sm text-oh-text-muted flex-wrap">
+              <span data-testid="trigger-reason">
+                <span className="font-medium">Trigger reason:</span> {triggerReason}
+              </span>
               <span data-testid="triggered-by">
                 <span className="font-medium">Triggered by:</span> {triggeredBy}
               </span>

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import type { RunMetadata, DayRunGroup } from '../api'
-import { getStageStatus, getRuntime, isFinished, extractTriggeredBy } from '../api'
+import { getStageStatus, getRuntime, isFinished, extractTriggeredBy, extractTriggerReason } from '../api'
 
 interface RunInfo {
   slug: string
@@ -130,7 +130,8 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
       const runtime: string | null = metadata ? getRuntime(metadata, now) : null
       const runFinished = metadata ? isFinished(metadata) : true
       const triggeredBy = extractTriggeredBy(metadata)
-      return { ...run, status, runtime, runFinished, triggeredBy }
+      const triggerReason = extractTriggerReason(metadata)
+      return { ...run, status, runtime, runFinished, triggeredBy, triggerReason }
     })
   }, [runs, runMetadataMap, now])
 
@@ -281,13 +282,14 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
                 <th className="text-left text-xs font-medium text-oh-text-muted uppercase tracking-wider px-4 py-3">Model</th>
                 <th className="text-left text-xs font-medium text-oh-text-muted uppercase tracking-wider px-4 py-3">Job ID</th>
                 <th className="text-left text-xs font-medium text-oh-text-muted uppercase tracking-wider px-4 py-3">Runtime</th>
+                <th className="text-left text-xs font-medium text-oh-text-muted uppercase tracking-wider px-4 py-3">Trigger Reason</th>
                 <th className="text-left text-xs font-medium text-oh-text-muted uppercase tracking-wider px-4 py-3">Triggered By</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-oh-border">
               {filteredRuns.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-oh-text-muted">
+                  <td colSpan={7} className="px-4 py-8 text-center text-sm text-oh-text-muted">
                     No runs match the current filters.
                   </td>
                 </tr>
@@ -301,7 +303,7 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
                     <React.Fragment key={run.slug}>
                       {showDateHeader && (
                         <tr className="bg-oh-bg">
-                          <td colSpan={6} className="px-4 py-2">
+                          <td colSpan={7} className="px-4 py-2">
                             <span className="text-xs font-semibold text-oh-text-muted uppercase tracking-wider">
                               {runDate}
                             </span>
@@ -337,6 +339,11 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
                           ) : (
                             <span className="text-sm text-oh-text-muted">—</span>
                           )}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className="text-sm text-oh-text-muted truncate max-w-[200px] inline-block" title={run.triggerReason}>
+                            {run.triggerReason}
+                          </span>
                         </td>
                         <td className="px-4 py-3 whitespace-nowrap">
                           <span className="text-sm text-oh-text-muted">


### PR DESCRIPTION
## Summary

Adds "Trigger Reason" display to both the main run list table and the run detail page top section, as requested in #35.

## Changes

### `frontend/src/api.ts`
- Added `extractTriggerReason()` helper function that extracts trigger reason from metadata, looking for `trigger_reason`, `event_name`, or `event_type` keys in `params` and `init` data (with params taking priority)

### `frontend/src/components/RunListView.tsx`
- Added "Trigger Reason" column to the main table (between Runtime and Triggered By)
- Includes truncation with tooltip for long reason strings
- Updated `colSpan` values for empty-state and date-header rows

### `frontend/src/components/RunDetailView.tsx`
- Added "Trigger reason:" field to the top header section (before "Triggered by:" and "Runtime:")
- Added `data-testid="trigger-reason"` for test targeting
- Added `flex-wrap` to the info row for responsive layout

### Tests
- Added 9 tests for `extractTriggerReason()` in `api.test.ts` covering: undefined metadata, null sources, extraction from params/init, priority ordering, alternative keys, non-string values, null values, and empty strings
- Added 3 tests for trigger reason display in `RunDetailView.test.tsx` covering: showing reason from metadata, dash fallback when no reason, and dash when metadata is null

## Verification

All 107 tests pass, TypeScript build succeeds.

Closes #35