### PR TITLE
fix: show runtime duration instead of timestamps in Pipeline Progress

### DIFF
--- a/frontend/src/__tests__/StatusTimeline.test.tsx
+++ b/frontend/src/__tests__/StatusTimeline.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import StatusTimeline, { formatStageDuration } from '../components/StatusTimeline'
+import type { RunMetadata } from '../api'
+
+function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
+  return {
+    init: null,
+    params: null,
+    error: null,
+    runInferStart: null,
+    runInferEnd: null,
+    evalInferStart: null,
+    evalInferEnd: null,
+    ...overrides,
+  }
+}
+
+describe('formatStageDuration', () => {
+  it('returns dash when startStr is null', () => {
+    expect(formatStageDuration(null, null, false, Date.now())).toBe('—')
+  })
+
+  it('returns dash when startStr is invalid', () => {
+    expect(formatStageDuration('not-a-date', '2025-03-15T11:00:00Z', false, Date.now())).toBe('—')
+  })
+
+  it('returns dash when endStr is null and not active', () => {
+    expect(formatStageDuration('2025-03-15T10:00:00Z', null, false, Date.now())).toBe('—')
+  })
+
+  it('returns duration between start and end for completed stage', () => {
+    expect(formatStageDuration('2025-03-15T10:00:00Z', '2025-03-15T11:30:00Z', false, Date.now())).toBe('1h 30m')
+  })
+
+  it('returns duration between start and now for active stage', () => {
+    const now = new Date('2025-03-15T10:45:00Z').getTime()
+    expect(formatStageDuration('2025-03-15T10:00:00Z', null, true, now)).toBe('45m 0s')
+  })
+
+  it('returns seconds for short durations', () => {
+    expect(formatStageDuration('2025-03-15T10:00:00Z', '2025-03-15T10:00:30Z', false, Date.now())).toBe('30s')
+  })
+
+  it('returns minutes and seconds for medium durations', () => {
+    expect(formatStageDuration('2025-03-15T10:00:00Z', '2025-03-15T10:05:30Z', false, Date.now())).toBe('5m 30s')
+  })
+
+  it('returns dash for negative duration', () => {
+    expect(formatStageDuration('2025-03-15T11:00:00Z', '2025-03-15T10:00:00Z', false, Date.now())).toBe('—')
+  })
+})
+
+describe('StatusTimeline', () => {
+  it('shows duration instead of timestamp for completed stages', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:06:00Z' },
+      runInferEnd: { timestamp: '2025-03-15T11:06:00Z' },
+      evalInferStart: { timestamp: '2025-03-15T11:07:00Z' },
+      evalInferEnd: { timestamp: '2025-03-15T12:07:00Z' },
+    })
+    const { container } = render(<StatusTimeline metadata={metadata} now={Date.now()} />)
+    const text = container.textContent!
+    // Should show durations
+    expect(text).toContain('5m 0s')   // Building Images: 10:00 -> 10:05
+    expect(text).toContain('1h 0m')   // Run Inference: 10:06 -> 11:06
+    // Should NOT show timestamps
+    expect(text).not.toContain('UTC')
+    expect(text).not.toMatch(/\d{2}:\d{2}:\d{2}/)
+  })
+
+  it('shows live duration for active stage using now prop', () => {
+    const now = new Date('2025-03-15T10:30:00Z').getTime()
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:06:00Z' },
+    })
+    const { container } = render(<StatusTimeline metadata={metadata} now={now} />)
+    const text = container.textContent!
+    // Building Images completed: 5m 0s
+    expect(text).toContain('5m 0s')
+    // Run Inference active: 10:06 -> 10:30 = 24m 0s
+    expect(text).toContain('24m 0s')
+    // No timestamps
+    expect(text).not.toContain('UTC')
+  })
+
+  it('shows no duration for pending stages', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+    })
+    const now = new Date('2025-03-15T10:30:00Z').getTime()
+    const { container } = render(<StatusTimeline metadata={metadata} now={now} />)
+    const pipelineSection = container.querySelector('.bg-oh-surface')!
+    const durationElements = pipelineSection.querySelectorAll('p.text-\\[10px\\]')
+    // Only "Building Images" is active, the other two are pending and should not show duration
+    // Building Images stage is active (params exists, init doesn't)
+    expect(durationElements.length).toBe(1)
+    expect(durationElements[0].textContent).toContain('30m 0s')
+  })
+
+  it('shows dash when start timestamp is missing', () => {
+    const metadata = makeMetadata({
+      params: { no_timestamp: true },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+    })
+    const { container } = render(<StatusTimeline metadata={metadata} now={Date.now()} />)
+    // Building Images: params has no timestamp -> should show "—"
+    const durationElements = container.querySelectorAll('p.text-\\[10px\\]')
+    const texts = Array.from(durationElements).map(el => el.textContent)
+    expect(texts).toContain('—')
+  })
+
+  it('never shows timestamps, only durations', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:06:00Z' },
+      runInferEnd: { timestamp: '2025-03-15T11:06:00Z' },
+    })
+    const now = new Date('2025-03-15T12:00:00Z').getTime()
+    const { container } = render(<StatusTimeline metadata={metadata} now={now} />)
+    const text = container.textContent!
+    expect(text).not.toContain('UTC')
+    expect(text).not.toMatch(/\d{2}:\d{2}:\d{2}/)
+  })
+})

--- a/frontend/src/components/StatusTimeline.tsx
+++ b/frontend/src/components/StatusTimeline.tsx
@@ -1,7 +1,9 @@
+import { useState, useEffect } from 'react'
 import type { RunMetadata } from '../api'
 
 interface StatusTimelineProps {
   metadata: RunMetadata
+  now?: number
 }
 
 interface Stage {
@@ -21,9 +23,12 @@ function getTimestamp(data: Record<string, unknown> | null): string | null {
   return (data.timestamp as string) || null
 }
 
-function formatDuration(startStr: string, endStr: string): string {
+export function formatStageDuration(startStr: string | null, endStr: string | null, isActive: boolean, now: number): string {
+  if (!startStr) return '—'
   const start = new Date(startStr).getTime()
-  const end = new Date(endStr).getTime()
+  if (isNaN(start)) return '—'
+  const end = isActive ? now : (endStr ? new Date(endStr).getTime() : NaN)
+  if (isNaN(end)) return '—'
   const diffMs = end - start
   if (diffMs < 0) return '—'
   const seconds = Math.floor(diffMs / 1000)
@@ -36,18 +41,18 @@ function formatDuration(startStr: string, endStr: string): string {
   return `${hours}h ${remainingMinutes}m`
 }
 
-function formatTime(ts: string): string {
-  return new Date(ts).toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-    timeZone: 'UTC',
-  }) + ' UTC'
-}
-
-export default function StatusTimeline({ metadata }: StatusTimelineProps) {
+export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelineProps) {
   const hasError = !!metadata.error
+  const [currentTime, setCurrentTime] = useState(nowProp ?? Date.now())
+
+  useEffect(() => {
+    if (nowProp !== undefined) {
+      setCurrentTime(nowProp)
+      return
+    }
+    const interval = setInterval(() => setCurrentTime(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [nowProp])
 
   return (
     <div className="bg-oh-surface border border-oh-border rounded-lg p-5">
@@ -83,16 +88,20 @@ export default function StatusTimeline({ metadata }: StatusTimelineProps) {
             error: 'bg-oh-error/40',
           }
 
+          const showDuration = isCompleted || isActive || (hasError && !!startData)
+          const durationText = showDuration
+            ? formatStageDuration(startTs, endTs, isActive, currentTime)
+            : null
+
+          const durationColor = isCompleted ? 'text-oh-success' : isActive ? 'text-oh-primary' : 'text-oh-text-muted'
+
           return (
             <div key={stage.label} className="flex items-center flex-1">
               <div className="flex flex-col items-center">
                 <div className={`w-3 h-3 rounded-full ${dotColors[stageStatus]} ${stageStatus === 'active' ? 'ring-4 ring-oh-primary/20' : ''}`} />
                 <p className="text-xs font-medium text-oh-text mt-2 whitespace-nowrap">{stage.label}</p>
-                {startTs && (
-                  <p className="text-[10px] text-oh-text-muted mt-0.5">{formatTime(startTs)}</p>
-                )}
-                {startTs && endTs && stage.endKey && isCompleted && (
-                  <p className="text-[10px] text-oh-success mt-0.5">{formatDuration(startTs, endTs)}</p>
+                {durationText && (
+                  <p className={`text-[10px] ${durationColor} mt-0.5`}>{durationText}</p>
                 )}
               </div>
               {i < STAGES.length - 1 && (


### PR DESCRIPTION
## Summary
Fixes #25

Replaces timestamp display with runtime duration in the Pipeline Progress section of the StatusTimeline component.

## Changes

### `frontend/src/components/StatusTimeline.tsx`
- **Removed** timestamp display (`formatTime` function and its usage) — timestamps are no longer shown in Pipeline Progress
- **Added** `formatStageDuration` helper that computes duration between start and end (or start and current time for active stages)
- **Completed stages**: show duration between stage start and end timestamps (e.g., "5m 0s", "1h 30m")
- **Active stages**: show live duration from stage start to current UTC time, updating every second via `setInterval`
- **Missing timestamps**: display "—" when start or end timestamp is unavailable
- **Added** `now` prop for testability (when provided, disables the interval timer)

### `frontend/src/__tests__/StatusTimeline.test.tsx` (new)
- 13 tests covering:
  - `formatStageDuration` unit tests (null/invalid inputs, completed/active stages, various duration formats)
  - Component integration tests verifying durations are shown, timestamps are never displayed, pending stages have no duration, and missing timestamps show "—"

## Testing
All 120 tests pass (5 test files), including 13 new StatusTimeline tests. TypeScript build succeeds.