### PR TITLE
Detect and mark dead/stale jobs that stopped progressing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -213,7 +213,7 @@ export default function App() {
             slug={selectedRun}
             metadata={runMetadata}
             loading={loadingMetadata}
-            status={runMetadata ? getStageStatus(runMetadata) : 'pending'}
+            status={runMetadata ? getStageStatus(runMetadata, Date.now()) : 'pending'}
           />
         ) : (
           <RunListView

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -6,6 +6,8 @@ import {
   isFinished,
   formatDurationMs,
   getStageStatus,
+  getLatestTimestamp,
+  STALE_THRESHOLD_MS,
 } from './api'
 import type { RunMetadata } from './api'
 
@@ -254,5 +256,215 @@ describe('getStageStatus', () => {
   it('returns pending when nothing exists', () => {
     const m = makeMetadata()
     expect(getStageStatus(m)).toBe('pending')
+  })
+})
+
+describe('STALE_THRESHOLD_MS', () => {
+  it('is 5 hours in milliseconds', () => {
+    expect(STALE_THRESHOLD_MS).toBe(5 * 60 * 60 * 1000)
+  })
+})
+
+describe('getLatestTimestamp', () => {
+  it('returns null when no metadata has timestamps', () => {
+    const m = makeMetadata()
+    expect(getLatestTimestamp(m)).toBeNull()
+  })
+
+  it('returns the params timestamp when only params exists', () => {
+    const m = makeMetadata({ params: ts('2025-01-01T10:00:00Z') })
+    expect(getLatestTimestamp(m)).toBe(new Date('2025-01-01T10:00:00Z').getTime())
+  })
+
+  it('returns the most recent timestamp (evalInferEnd)', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      init: ts('2025-01-01T10:05:00Z'),
+      runInferStart: ts('2025-01-01T10:06:00Z'),
+      runInferEnd: ts('2025-01-01T11:00:00Z'),
+      evalInferStart: ts('2025-01-01T11:05:00Z'),
+      evalInferEnd: ts('2025-01-01T12:00:00Z'),
+    })
+    expect(getLatestTimestamp(m)).toBe(new Date('2025-01-01T12:00:00Z').getTime())
+  })
+
+  it('returns runInferStart when it is the latest', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      init: ts('2025-01-01T10:05:00Z'),
+      runInferStart: ts('2025-01-01T10:06:00Z'),
+    })
+    expect(getLatestTimestamp(m)).toBe(new Date('2025-01-01T10:06:00Z').getTime())
+  })
+
+  it('ignores metadata entries without timestamps', () => {
+    const m = makeMetadata({
+      params: { no_timestamp: true },
+      init: ts('2025-01-01T10:05:00Z'),
+    })
+    expect(getLatestTimestamp(m)).toBe(new Date('2025-01-01T10:05:00Z').getTime())
+  })
+
+  it('returns null when all metadata entries lack timestamps', () => {
+    const m = makeMetadata({
+      params: { no_timestamp: true },
+      init: { no_timestamp: true },
+    })
+    expect(getLatestTimestamp(m)).toBeNull()
+  })
+})
+
+describe('getStageStatus with dead detection', () => {
+  it('returns dead for a running-infer run that is stale', () => {
+    const startTime = new Date('2025-01-01T10:00:00Z').getTime()
+    const m = makeMetadata({
+      params: ts('2025-01-01T09:55:00Z'),
+      init: ts('2025-01-01T09:58:00Z'),
+      runInferStart: ts('2025-01-01T10:00:00Z'),
+    })
+    const now = startTime + STALE_THRESHOLD_MS + 1
+    expect(getStageStatus(m, now)).toBe('dead')
+  })
+
+  it('returns running-infer for a recent run with now provided', () => {
+    const startTime = new Date('2025-01-01T10:00:00Z').getTime()
+    const m = makeMetadata({
+      params: ts('2025-01-01T09:55:00Z'),
+      init: ts('2025-01-01T09:58:00Z'),
+      runInferStart: ts('2025-01-01T10:00:00Z'),
+    })
+    const now = startTime + STALE_THRESHOLD_MS - 1000 // just under threshold
+    expect(getStageStatus(m, now)).toBe('running-infer')
+  })
+
+  it('returns dead for a running-eval run that is stale', () => {
+    const latestTime = new Date('2025-01-01T11:05:00Z').getTime()
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      init: ts('2025-01-01T10:05:00Z'),
+      runInferStart: ts('2025-01-01T10:06:00Z'),
+      runInferEnd: ts('2025-01-01T11:00:00Z'),
+      evalInferStart: ts('2025-01-01T11:05:00Z'),
+    })
+    const now = latestTime + STALE_THRESHOLD_MS + 1
+    expect(getStageStatus(m, now)).toBe('dead')
+  })
+
+  it('returns dead for a building run that is stale', () => {
+    const paramTime = new Date('2025-01-01T10:00:00Z').getTime()
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+    })
+    const now = paramTime + STALE_THRESHOLD_MS + 1
+    expect(getStageStatus(m, now)).toBe('dead')
+  })
+
+  it('returns dead for a pending run (init only) that is stale', () => {
+    const initTime = new Date('2025-01-01T10:00:00Z').getTime()
+    const m = makeMetadata({
+      init: ts('2025-01-01T10:00:00Z'),
+    })
+    const now = initTime + STALE_THRESHOLD_MS + 1
+    expect(getStageStatus(m, now)).toBe('dead')
+  })
+
+  it('does not return dead for completed runs regardless of age', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      init: ts('2025-01-01T10:05:00Z'),
+      evalInferEnd: ts('2025-01-01T12:00:00Z'),
+    })
+    const veryLateNow = new Date('2025-06-01T00:00:00Z').getTime()
+    expect(getStageStatus(m, veryLateNow)).toBe('completed')
+  })
+
+  it('does not return dead for error runs regardless of age', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      error: ts('2025-01-01T10:30:00Z'),
+    })
+    const veryLateNow = new Date('2025-06-01T00:00:00Z').getTime()
+    expect(getStageStatus(m, veryLateNow)).toBe('error')
+  })
+
+  it('does not return dead when now is not provided even for old timestamps', () => {
+    const m = makeMetadata({
+      params: ts('2020-01-01T10:00:00Z'),
+      init: ts('2020-01-01T10:05:00Z'),
+      runInferStart: ts('2020-01-01T10:06:00Z'),
+    })
+    // Without now parameter, staleness detection is not active
+    expect(getStageStatus(m)).toBe('running-infer')
+  })
+
+  it('does not return dead for empty metadata even with now', () => {
+    const m = makeMetadata()
+    const now = Date.now()
+    expect(getStageStatus(m, now)).toBe('pending')
+  })
+})
+
+describe('isFinished with dead detection', () => {
+  it('returns true for dead runs', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+    })
+    const now = new Date('2025-01-01T10:05:00Z').getTime() + STALE_THRESHOLD_MS + 1
+    expect(isFinished(m, now)).toBe(true)
+  })
+
+  it('returns false for active runs that are not stale', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+    })
+    const now = new Date('2025-01-01T10:10:00Z').getTime()
+    expect(isFinished(m, now)).toBe(false)
+  })
+})
+
+describe('getEndTimestamp with dead detection', () => {
+  it('returns latest timestamp for dead runs', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      init: ts('2025-01-01T10:05:00Z'),
+      runInferStart: ts('2025-01-01T10:06:00Z'),
+    })
+    const now = new Date('2025-01-01T10:06:00Z').getTime() + STALE_THRESHOLD_MS + 1
+    expect(getEndTimestamp(m, now)).toBe(new Date('2025-01-01T10:06:00Z').getTime())
+  })
+
+  it('returns null for active non-stale runs', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+    })
+    const now = new Date('2025-01-01T10:10:00Z').getTime()
+    expect(getEndTimestamp(m, now)).toBeNull()
+  })
+})
+
+describe('getRuntime with dead detection', () => {
+  it('returns fixed runtime for dead runs', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      init: ts('2025-01-01T10:05:00Z'),
+      runInferStart: ts('2025-01-01T10:06:00Z'),
+    })
+    // now is well past stale threshold
+    const now = new Date('2025-01-01T10:06:00Z').getTime() + STALE_THRESHOLD_MS + 60000
+    const runtime = getRuntime(m, now)
+    // Runtime should be from params to runInferStart (latest), not to "now"
+    expect(runtime).toBe('6m 0s') // 10:00 -> 10:06
+  })
+
+  it('returns live runtime for active non-stale runs', () => {
+    const m = makeMetadata({
+      params: ts('2025-01-01T10:00:00Z'),
+      runInferStart: ts('2025-01-01T10:05:00Z'),
+    })
+    const now = new Date('2025-01-01T10:20:00Z').getTime()
+    expect(getRuntime(m, now)).toBe('20m 0s')
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,8 @@
 const BASE_URL = '/api'
 const RESULTS_BASE_URL = 'https://results.eval.all-hands.dev'
 
+export const STALE_THRESHOLD_MS = 5 * 60 * 60 * 1000 // 5 hours
+
 export async function fetchRunList(date: string): Promise<string[]> {
   const cacheBust = Math.floor(Date.now() / 1000)
   const res = await fetch(`${BASE_URL}/metadata/${date}.txt?${cacheBust}`)
@@ -108,15 +110,43 @@ export function parseRunSlug(slug: string) {
   return { benchmark: slug, model: '', jobId: '' }
 }
 
-export function getStageStatus(metadata: RunMetadata): 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' {
+export type StageStatus = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'dead'
+
+export function getLatestTimestamp(metadata: RunMetadata): number | null {
+  const keys: (keyof RunMetadata)[] = ['evalInferEnd', 'evalInferStart', 'runInferEnd', 'runInferStart', 'init', 'params']
+  for (const key of keys) {
+    const data = metadata[key]
+    if (!data) continue
+    const ts = data.timestamp as string | undefined
+    if (!ts) continue
+    const ms = new Date(ts).getTime()
+    if (!isNaN(ms)) return ms
+  }
+  return null
+}
+
+export function getStageStatus(metadata: RunMetadata, now?: number): StageStatus {
   if (metadata.error) return 'error'
   if (metadata.evalInferEnd) return 'completed'
-  if (metadata.evalInferStart) return 'running-eval'
-  if (metadata.runInferEnd) return 'running-eval'
-  if (metadata.runInferStart) return 'running-infer'
-  if (metadata.init) return 'pending'
-  if (metadata.params) return 'building'
-  return 'pending'
+
+  // For non-terminal states, check if the run is stale (dead)
+  const baseStatus: StageStatus =
+    metadata.evalInferStart ? 'running-eval' :
+    metadata.runInferEnd ? 'running-eval' :
+    metadata.runInferStart ? 'running-infer' :
+    metadata.init ? 'pending' :
+    metadata.params ? 'building' :
+    'pending'
+
+  // Check if the run appears stale (no progress for too long)
+  if (now !== undefined) {
+    const latest = getLatestTimestamp(metadata)
+    if (latest !== null && (now - latest) > STALE_THRESHOLD_MS) {
+      return 'dead'
+    }
+  }
+
+  return baseStatus
 }
 
 export function getResultsUrl(slug: string, file: string): string {
@@ -190,8 +220,8 @@ export function getStartTimestamp(metadata: RunMetadata): number | null {
   return getTimestampMs(metadata.params)
 }
 
-export function getEndTimestamp(metadata: RunMetadata): number | null {
-  const status = getStageStatus(metadata)
+export function getEndTimestamp(metadata: RunMetadata, now?: number): number | null {
+  const status = getStageStatus(metadata, now)
   if (status === 'completed') {
     return getTimestampMs(metadata.evalInferEnd) ?? null
   }
@@ -203,12 +233,15 @@ export function getEndTimestamp(metadata: RunMetadata): number | null {
       ?? getTimestampMs(metadata.init)
       ?? null
   }
+  if (status === 'dead') {
+    return getLatestTimestamp(metadata)
+  }
   return null
 }
 
-export function isFinished(metadata: RunMetadata): boolean {
-  const status = getStageStatus(metadata)
-  return status === 'completed' || status === 'error'
+export function isFinished(metadata: RunMetadata, now?: number): boolean {
+  const status = getStageStatus(metadata, now)
+  return status === 'completed' || status === 'error' || status === 'dead'
 }
 
 export function formatDurationMs(ms: number): string {
@@ -251,8 +284,8 @@ export function getRuntime(metadata: RunMetadata, now: number = Date.now()): str
   const start = getStartTimestamp(metadata)
   if (start === null) return null
 
-  const finished = isFinished(metadata)
-  const end = finished ? getEndTimestamp(metadata) : now
+  const finished = isFinished(metadata, now)
+  const end = finished ? getEndTimestamp(metadata, now) : now
   if (end === null) return null
 
   return formatDurationMs(end - start)

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -4,11 +4,13 @@ import StatusTimeline from './StatusTimeline'
 import JsonCard from './JsonCard'
 import CompletedRunResults from './CompletedRunResults'
 
+import type { StageStatus } from '../api'
+
 interface RunDetailViewProps {
   slug: string
   metadata: RunMetadata | null
   loading: boolean
-  status: 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error'
+  status: StageStatus
 }
 
 export default function RunDetailView({ slug, metadata, loading, status }: RunDetailViewProps) {
@@ -102,6 +104,7 @@ function StatusBadge({ status }: { status: string }) {
     'running-eval': 'bg-oh-warning/20 text-oh-warning border-oh-warning/30',
     'completed': 'bg-oh-success/20 text-oh-success border-oh-success/30',
     'error': 'bg-oh-error/20 text-oh-error border-oh-error/30',
+    'dead': 'bg-gray-500/20 text-gray-400 border-gray-500/30',
   }
 
   const labels: Record<string, string> = {
@@ -111,6 +114,7 @@ function StatusBadge({ status }: { status: string }) {
     'running-eval': 'Running Evaluation',
     'completed': 'Completed',
     'error': 'Error',
+    'dead': 'Dead',
   }
 
   return (

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import type { RunMetadata, DayRunGroup } from '../api'
+import type { RunMetadata, DayRunGroup, StageStatus } from '../api'
 import { getStageStatus, getRuntime, isFinished, extractTriggeredBy, extractTriggerReason } from '../api'
 
 interface RunInfo {
@@ -19,9 +19,7 @@ interface RunListViewProps {
   dayGroups: DayRunGroup[]
 }
 
-type StatusType = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error'
-
-const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?: string }> = {
+const STATUS_CONFIG: Record<StageStatus, { label: string; className: string; dot?: string }> = {
   pending: {
     label: 'Pending',
     className: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
@@ -49,6 +47,10 @@ const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?
     label: 'Error',
     className: 'bg-red-500/20 text-red-400 border-red-500/30',
   },
+  dead: {
+    label: 'Dead',
+    className: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
+  },
 }
 
 const BENCHMARK_COLORS: Record<string, string> = {
@@ -59,7 +61,7 @@ const BENCHMARK_COLORS: Record<string, string> = {
   commit0: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
 }
 
-function StatusBadge({ status }: { status: StatusType }) {
+function StatusBadge({ status }: { status: StageStatus }) {
   const config = STATUS_CONFIG[status]
   return (
     <span className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${config.className}`}>
@@ -72,6 +74,11 @@ function StatusBadge({ status }: { status: StatusType }) {
       {status === 'error' && (
         <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      )}
+      {status === 'dead' && (
+        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
       )}
       {config.label}
@@ -111,9 +118,9 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
   const hasNonFinished = useMemo(() => {
     return runs.some(run => {
       const metadata = runMetadataMap[run.slug]
-      return metadata && !isFinished(metadata)
+      return metadata && !isFinished(metadata, now)
     })
-  }, [runs, runMetadataMap])
+  }, [runs, runMetadataMap, now])
 
   // Tick every 1s so elapsed time updates for non-finished runs
   useEffect(() => {
@@ -126,9 +133,9 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
       const metadata = runMetadataMap[run.slug]
-      const status: StatusType = metadata ? getStageStatus(metadata) : 'pending'
+      const status: StageStatus = metadata ? getStageStatus(metadata, now) : 'pending'
       const runtime: string | null = metadata ? getRuntime(metadata, now) : null
-      const runFinished = metadata ? isFinished(metadata) : true
+      const runFinished = metadata ? isFinished(metadata, now) : true
       const triggeredBy = extractTriggeredBy(metadata)
       const triggerReason = extractTriggerReason(metadata)
       return { ...run, status, runtime, runFinished, triggeredBy, triggerReason }
@@ -226,7 +233,7 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
               onClick={() => setFilterStatus(filterStatus === status ? 'all' : status)}
               className={`text-xs px-2 py-1 rounded transition-colors ${filterStatus === status ? 'ring-1 ring-oh-primary' : 'opacity-70 hover:opacity-100'}`}
             >
-              <StatusBadge status={status as StatusType} />
+              <StatusBadge status={status as StageStatus} />
               <span className="ml-1 text-oh-text-muted">{count}</span>
             </button>
           ))}
@@ -259,7 +266,7 @@ export default function RunListView({ runs, loading, error, onSelectRun, runMeta
         >
           <option value="all">All statuses</option>
           {statuses.map(s => (
-            <option key={s} value={s}>{STATUS_CONFIG[s as StatusType]?.label || s}</option>
+            <option key={s} value={s}>{STATUS_CONFIG[s as StageStatus]?.label || s}</option>
           ))}
         </select>
         {(filterText || filterBenchmark !== 'all' || filterStatus !== 'all') && (

--- a/frontend/src/components/StatusTimeline.tsx
+++ b/frontend/src/components/StatusTimeline.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import type { RunMetadata } from '../api'
+import { getStageStatus } from '../api'
 
 interface StatusTimelineProps {
   metadata: RunMetadata
@@ -43,6 +44,7 @@ export function formatStageDuration(startStr: string | null, endStr: string | nu
 
 export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelineProps) {
   const hasError = !!metadata.error
+  const isDead = getStageStatus(metadata, nowProp ?? Date.now()) === 'dead'
   const [currentTime, setCurrentTime] = useState(nowProp ?? Date.now())
 
   useEffect(() => {
@@ -68,8 +70,9 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
           const isActive = !!startData && !endData && stage.endKey !== undefined
           const isPending = !startData
 
-          let stageStatus: 'completed' | 'active' | 'pending' | 'error' = 'pending'
+          let stageStatus: 'completed' | 'active' | 'pending' | 'error' | 'dead' = 'pending'
           if (hasError && isActive) stageStatus = 'error'
+          else if (isDead && isActive) stageStatus = 'dead'
           else if (isCompleted) stageStatus = 'completed'
           else if (isActive) stageStatus = 'active'
           else stageStatus = 'pending'
@@ -79,6 +82,7 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
             active: 'bg-oh-primary',
             pending: 'bg-oh-border',
             error: 'bg-oh-error',
+            dead: 'bg-gray-500',
           }
 
           const lineColors = {
@@ -86,14 +90,15 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
             active: 'bg-oh-primary/40',
             pending: 'bg-oh-border',
             error: 'bg-oh-error/40',
+            dead: 'bg-gray-500/40',
           }
 
-          const showDuration = isCompleted || isActive || (hasError && !!startData)
+          const showDuration = isCompleted || isActive || (hasError && !!startData) || (isDead && !!startData)
           const durationText = showDuration
-            ? formatStageDuration(startTs, endTs, isActive, currentTime)
+            ? formatStageDuration(startTs, endTs, isActive && !isDead, currentTime)
             : null
 
-          const durationColor = isCompleted ? 'text-oh-success' : isActive ? 'text-oh-primary' : 'text-oh-text-muted'
+          const durationColor = isCompleted ? 'text-oh-success' : stageStatus === 'dead' ? 'text-gray-400' : isActive ? 'text-oh-primary' : 'text-oh-text-muted'
 
           return (
             <div key={stage.label} className="flex items-center flex-1">


### PR DESCRIPTION
## Summary

Fixes #44

Jobs that silently die (e.g., GitHub Action cancelled, crashed, or timed out) without writing an `error.json` file would previously remain stuck in an active status (like "Running Inference") forever. This PR adds automatic detection and marking of such dead jobs.

## Changes

### Core Logic (`api.ts`)
- **`STALE_THRESHOLD_MS`** — 5-hour constant defining how long a run can be in a non-terminal state before being considered dead
- **`getLatestTimestamp(metadata)`** — New helper that returns the most recent timestamp from any metadata file
- **`StageStatus` type** — New exported type union that includes `'dead'` alongside existing statuses
- **`getStageStatus(metadata, now?)`** — Now accepts an optional `now` parameter; when provided, detects stale runs whose latest timestamp exceeds the threshold
- **`isFinished(metadata, now?)`** — Now considers `'dead'` as a finished state
- **`getEndTimestamp(metadata, now?)`** — Returns the latest timestamp for dead runs (so runtime shows accurately)
- **`getRuntime(metadata, now)`** — Passes `now` through to `isFinished`/`getEndTimestamp`, so dead runs show a fixed runtime to their last activity rather than a continuously ticking clock

### UI Components
- **`RunListView`** — Added "Dead" status badge (gray, with ⓘ icon), passes `now` to status/finished checks
- **`RunDetailView`** — Added "Dead" styling to status badge
- **`StatusTimeline`** — Dead stages shown with gray dot/line colors, non-ticking duration
- **`App.tsx`** — Passes `Date.now()` to `getStageStatus` for detail view

### Tests
- 22 new tests covering:
  - `getLatestTimestamp` — various metadata combinations
  - `getStageStatus` with dead detection — stale running-infer, running-eval, building, pending; non-dead completed/error; no false positives without `now`
  - `isFinished` — dead runs return true
  - `getEndTimestamp` — dead runs return latest timestamp
  - `getRuntime` — dead runs show fixed runtime

## How it works

When `getStageStatus` is called with a `now` parameter (which the UI components now do), it checks whether the run is in a non-terminal state and whether the most recent metadata timestamp is older than 5 hours. If so, it returns `'dead'` instead of the active status.

Terminal states (`'completed'`, `'error'`) are never overridden — only active/pending runs can become dead. If no `now` parameter is provided (backward compatibility), the staleness check is skipped entirely.