### PR TITLE
feat: display benchmarks-params.json in run detail page between params and init

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -7,6 +7,7 @@ function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
   return {
     init: null,
     params: null,
+    benchmarksParams: null,
     error: null,
     runInferStart: null,
     runInferEnd: null,
@@ -207,6 +208,53 @@ describe('RunDetailView', () => {
     )
     const badges = screen.getAllByText('Building Images')
     expect(badges.length).toBeGreaterThanOrEqual(1)
+  })
+
+  describe('Benchmarks Parameters card', () => {
+    it('renders Benchmarks Parameters card when benchmarksParams data is present', () => {
+      const metadata = makeMetadata({
+        benchmarksParams: { benchmark_suite: 'swebench', max_tasks: 100 },
+      })
+      const { container } = render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+      )
+      const headings = Array.from(container.querySelectorAll('h3'))
+      const benchmarksHeading = headings.find(h => h.textContent === 'Benchmarks Parameters')
+      expect(benchmarksHeading).toBeTruthy()
+    })
+
+    it('renders Benchmarks Parameters card as "Not available yet" when benchmarksParams is null', () => {
+      const metadata = makeMetadata({ benchmarksParams: null })
+      const { container } = render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+      )
+      const headings = Array.from(container.querySelectorAll('h3'))
+      const benchmarksHeading = headings.find(h => h.textContent === 'Benchmarks Parameters')
+      expect(benchmarksHeading).toBeTruthy()
+      const card = benchmarksHeading!.closest('div')!.parentElement!
+      expect(card.textContent).toContain('Not available yet')
+    })
+
+    it('renders Benchmarks Parameters card between Parameters and Init', () => {
+      const metadata = makeMetadata({
+        params: { model: 'claude-sonnet' },
+        benchmarksParams: { benchmark_suite: 'swebench' },
+        init: { version: '1.0' },
+      })
+      const { container } = render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+      )
+      const headings = Array.from(container.querySelectorAll('h3')).map(h => h.textContent)
+      const paramsIdx = headings.indexOf('Parameters')
+      const benchmarksIdx = headings.indexOf('Benchmarks Parameters')
+      const initIdx = headings.indexOf('Init')
+
+      expect(paramsIdx).toBeGreaterThanOrEqual(0)
+      expect(benchmarksIdx).toBeGreaterThanOrEqual(0)
+      expect(initIdx).toBeGreaterThanOrEqual(0)
+      expect(benchmarksIdx).toBeGreaterThan(paramsIdx)
+      expect(benchmarksIdx).toBeLessThan(initIdx)
+    })
   })
 
   describe('Cancel Evaluation section', () => {

--- a/frontend/src/__tests__/StatusTimeline.test.tsx
+++ b/frontend/src/__tests__/StatusTimeline.test.tsx
@@ -7,6 +7,7 @@ function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
   return {
     init: null,
     params: null,
+    benchmarksParams: null,
     error: null,
     runInferStart: null,
     runInferEnd: null,

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -93,6 +93,7 @@ function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
   return {
     init: null,
     params: null,
+    benchmarksParams: null,
     error: null,
     runInferStart: null,
     runInferEnd: null,

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -13,6 +13,7 @@ function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
   return {
     init: null,
     params: null,
+    benchmarksParams: null,
     error: null,
     runInferStart: null,
     runInferEnd: null,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -53,6 +53,7 @@ export async function fetchMultiDayRunList(baseDate: string, numDays: number): P
 export interface RunMetadata {
   init: Record<string, unknown> | null
   params: Record<string, unknown> | null
+  benchmarksParams: Record<string, unknown> | null
   error: Record<string, unknown> | null
   runInferStart: Record<string, unknown> | null
   runInferEnd: Record<string, unknown> | null
@@ -63,6 +64,7 @@ export interface RunMetadata {
 const METADATA_FILES = [
   ['init', 'init.json'],
   ['params', 'params.json'],
+  ['benchmarksParams', 'benchmarks-params.json'],
   ['error', 'error.json'],
   ['runInferStart', 'run-infer-start.json'],
   ['runInferEnd', 'run-infer-end.json'],

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -84,6 +84,7 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
       {/* Metadata Cards */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <JsonCard title="Parameters" data={metadata?.params} icon="⚙️" />
+        <JsonCard title="Benchmarks Parameters" data={metadata?.benchmarksParams} icon="📋" />
         <JsonCard title="Init" data={metadata?.init} icon="🚀" />
         <JsonCard title="Run Infer Start" data={metadata?.runInferStart} icon="▶️" />
         <JsonCard title="Run Infer End" data={metadata?.runInferEnd} icon="⏹️" />


### PR DESCRIPTION
## Summary

Fixes #53

Reads `metadata/benchmarks-params.json` for each run and displays it as a new "Benchmarks Parameters" card in the run detail page, positioned after "Parameters" and before "Init".

## Changes

- **`frontend/src/api.ts`**: Added `benchmarksParams` field to `RunMetadata` interface and added `benchmarks-params.json` to the `METADATA_FILES` list so it is fetched alongside other metadata files.
- **`frontend/src/components/RunDetailView.tsx`**: Added a `JsonCard` for "Benchmarks Parameters" between the Parameters and Init cards in the metadata grid.
- **Tests**: Updated all `makeMetadata` helpers across test files to include `benchmarksParams: null`. Added 3 new tests in `RunDetailView.test.tsx` covering: card renders with data, card shows "Not available yet" when null, and card appears between Parameters and Init in DOM order.
