### PR TITLE
feat: show kubernetes_jobs_found and helm_releases_found in cancelled section

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -381,5 +381,67 @@ describe('RunDetailView', () => {
       )
       expect(screen.queryByTestId('cancel-evaluation-section')).toBeNull()
     })
+
+    it('shows kubernetes_jobs_found when present in cancelEval', () => {
+      const metadata = makeMetadata({
+        cancelEval: { timestamp: '2025-03-15T10:45:00Z', cancelled_by: 'alice', kubernetes_jobs_found: 3 },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      const el = screen.getByTestId('kubernetes-jobs-found')
+      expect(el.textContent).toContain('Kubernetes jobs found:')
+      expect(el.textContent).toContain('3')
+    })
+
+    it('shows helm_releases_found when present in cancelEval', () => {
+      const metadata = makeMetadata({
+        cancelEval: { timestamp: '2025-03-15T10:45:00Z', cancelled_by: 'alice', helm_releases_found: 5 },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      const el = screen.getByTestId('helm-releases-found')
+      expect(el.textContent).toContain('Helm releases found:')
+      expect(el.textContent).toContain('5')
+    })
+
+    it('does not show kubernetes_jobs_found when absent from cancelEval', () => {
+      const metadata = makeMetadata({
+        cancelEval: { timestamp: '2025-03-15T10:45:00Z', cancelled_by: 'alice' },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      expect(screen.queryByTestId('kubernetes-jobs-found')).toBeNull()
+    })
+
+    it('does not show helm_releases_found when absent from cancelEval', () => {
+      const metadata = makeMetadata({
+        cancelEval: { timestamp: '2025-03-15T10:45:00Z', cancelled_by: 'alice' },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      expect(screen.queryByTestId('helm-releases-found')).toBeNull()
+    })
+
+    it('shows both kubernetes_jobs_found and helm_releases_found when both present', () => {
+      const metadata = makeMetadata({
+        cancelEval: {
+          timestamp: '2025-03-15T10:45:00Z',
+          cancelled_by: 'alice',
+          kubernetes_jobs_found: 2,
+          helm_releases_found: 4,
+        },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      const k8sEl = screen.getByTestId('kubernetes-jobs-found')
+      expect(k8sEl.textContent).toContain('2')
+      const helmEl = screen.getByTestId('helm-releases-found')
+      expect(helmEl.textContent).toContain('4')
+    })
   })
 })

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -86,6 +86,18 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
                   <span className="font-medium">Cancelled by:</span>{' '}
                   {extractCancelledBy(metadata.cancelEval)}
                 </span>
+                {metadata.cancelEval.kubernetes_jobs_found !== undefined && (
+                  <span data-testid="kubernetes-jobs-found">
+                    <span className="font-medium">Kubernetes jobs found:</span>{' '}
+                    {String(metadata.cancelEval.kubernetes_jobs_found)}
+                  </span>
+                )}
+                {metadata.cancelEval.helm_releases_found !== undefined && (
+                  <span data-testid="helm-releases-found">
+                    <span className="font-medium">Helm releases found:</span>{' '}
+                    {String(metadata.cancelEval.helm_releases_found)}
+                  </span>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Fixes #55

When a job is cancelled, the **Evaluation Cancelled** section in the detail view now also shows `kubernetes_jobs_found` and `helm_releases_found` fields from the `cancel-eval.json` metadata, when they are present.

## Changes

- **`frontend/src/components/RunDetailView.tsx`**: Added conditional rendering of `kubernetes_jobs_found` and `helm_releases_found` fields inside the cancelled section. Each field is only rendered when present in the `cancelEval` data.

- **`frontend/src/__tests__/RunDetailView.test.tsx`**: Added 5 new tests covering:
  - Shows `kubernetes_jobs_found` when present
  - Shows `helm_releases_found` when present
  - Does not show `kubernetes_jobs_found` when absent
  - Does not show `helm_releases_found` when absent
  - Shows both fields simultaneously when both are present
