### PR TITLE
Fix #65: Add copy link menus to sections on detail page

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -276,7 +276,7 @@ describe('RunDetailView', () => {
       el => el.textContent === 'Pipeline Progress'
     )
     expect(pipelineHeading).toBeTruthy()
-    const pipelineSection = pipelineHeading!.parentElement!
+    const pipelineSection = pipelineHeading!.closest('#pipeline-progress') || pipelineHeading!.parentElement!.parentElement!
     // Stage labels use specific classes; select only the label elements
     const stageLabels = Array.from(pipelineSection.querySelectorAll('p.text-xs.font-medium'))
       .map(p => p.textContent)

--- a/frontend/src/__tests__/SectionMenu.test.tsx
+++ b/frontend/src/__tests__/SectionMenu.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import SectionMenu from '../components/SectionMenu'
+
+describe('SectionMenu', () => {
+  beforeEach(() => {
+    // Mock navigator.clipboard
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+    
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'http://localhost/run/some-run-slug',
+      },
+      writable: true,
+    })
+  })
+
+  it('renders closed by default', () => {
+    render(<SectionMenu id="test-section" />)
+    expect(screen.queryByText('Copy link')).toBeNull()
+  })
+
+  it('opens menu when clicking the button', () => {
+    render(<SectionMenu id="test-section" />)
+    const button = screen.getByRole('button', { name: /section options/i })
+    
+    fireEvent.click(button)
+    
+    expect(screen.getByText('Copy link')).toBeInTheDocument()
+  })
+
+  it('copies correct URL to clipboard when copy link is clicked', async () => {
+    render(<SectionMenu id="test-section" />)
+    
+    // Open menu
+    fireEvent.click(screen.getByRole('button', { name: /section options/i }))
+    
+    // Click copy
+    const copyButton = screen.getByText('Copy link')
+    await act(async () => {
+      fireEvent.click(copyButton)
+    })
+    
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('http://localhost/run/some-run-slug#test-section')
+    expect(screen.getByText('Copied!')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react'
 import { fetchOutputReport, fetchCostReport, getResultsUrl } from '../api'
 import type { OutputReport, CostReport } from '../api'
 
+import SectionMenu from './SectionMenu'
+
 interface CompletedRunResultsProps {
   slug: string
 }
@@ -144,7 +146,7 @@ export default function CompletedRunResults({ slug }: CompletedRunResultsProps) 
 
   if (loading) {
     return (
-      <div className="bg-oh-surface border border-oh-success/30 rounded-lg p-4">
+      <div id="run-results" className="bg-oh-surface border border-oh-success/30 rounded-lg p-4 scroll-mt-6">
         <div className="flex items-center gap-2 text-oh-text-muted text-sm">
           <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
@@ -159,10 +161,13 @@ export default function CompletedRunResults({ slug }: CompletedRunResultsProps) 
   if (!outputReport && !costReport) return null
 
   return (
-    <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-oh-text flex items-center gap-2">
-        <span className="text-oh-success">✓</span> Run Results
-      </h3>
+    <div id="run-results" className="space-y-4 scroll-mt-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-oh-text flex items-center gap-2">
+          <span className="text-oh-success">✓</span> Run Results
+        </h3>
+        <SectionMenu id="run-results" />
+      </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {outputReport && <OutputReportCard report={outputReport} />}
         {costReport && <CostReportCard report={costReport} />}

--- a/frontend/src/components/ErrorReportSection.tsx
+++ b/frontend/src/components/ErrorReportSection.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { fetchErrorReport, getResultsUrl } from '../api'
 
+import SectionMenu from './SectionMenu'
+
 interface ErrorReportSectionProps {
   slug: string
 }
@@ -39,6 +41,15 @@ export default function ErrorReportSection({ slug }: ErrorReportSectionProps) {
     }
   }, [slug])
 
+  useEffect(() => {
+    if (!loading && errorReport && window.location.hash === '#error-report') {
+      setTimeout(() => {
+        const el = document.getElementById('error-report')
+        if (el) el.scrollIntoView({ behavior: 'smooth' })
+      }, 50)
+    }
+  }, [loading, errorReport])
+
   if (loading || !errorReport) return null
 
   const errorsUrl = getResultsUrl(slug, 'conversation-errors.txt')
@@ -48,10 +59,13 @@ export default function ErrorReportSection({ slug }: ErrorReportSectionProps) {
   const icon = noErrors ? "✅" : "⚠️"
 
   return (
-    <div data-testid="error-report-section" className="col-span-1 lg:col-span-2 bg-oh-surface border border-oh-border rounded-lg p-5">
-      <div className="flex items-center gap-2 mb-1">
-        <span className="text-xl">{icon}</span>
-        <h3 className="text-lg font-semibold text-oh-text">{title}</h3>
+    <div id="error-report" data-testid="error-report-section" className="col-span-1 lg:col-span-2 bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-6">
+      <div className="flex items-center justify-between mb-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xl">{icon}</span>
+          <h3 className="text-lg font-semibold text-oh-text">{title}</h3>
+        </div>
+        <SectionMenu id="error-report" />
       </div>
       {!noErrors && (
         <div className="mb-4">

--- a/frontend/src/components/JsonCard.tsx
+++ b/frontend/src/components/JsonCard.tsx
@@ -1,3 +1,5 @@
+import SectionMenu from './SectionMenu'
+
 interface JsonCardProps {
   title: string
   data: Record<string, unknown> | null | undefined
@@ -6,12 +8,17 @@ interface JsonCardProps {
 }
 
 export default function JsonCard({ title, data, icon, isError }: JsonCardProps) {
+  const sectionId = title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
   if (data === null || data === undefined) {
     return (
-      <div className="bg-oh-surface border border-oh-border rounded-lg p-4 opacity-50">
-        <div className="flex items-center gap-2 mb-3">
-          <span>{icon}</span>
-          <h3 className="text-sm font-medium text-oh-text-muted">{title}</h3>
+      <div id={sectionId} className="bg-oh-surface border border-oh-border rounded-lg p-4 opacity-50 scroll-mt-6">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <span>{icon}</span>
+            <h3 className="text-sm font-medium text-oh-text-muted">{title}</h3>
+          </div>
+          <SectionMenu id={sectionId} />
         </div>
         <p className="text-xs text-oh-text-muted italic">Not available yet</p>
       </div>
@@ -22,10 +29,13 @@ export default function JsonCard({ title, data, icon, isError }: JsonCardProps) 
   const bgClass = isError ? 'bg-oh-error/5' : 'bg-oh-surface'
 
   return (
-    <div className={`${bgClass} border ${borderClass} rounded-lg p-4`}>
-      <div className="flex items-center gap-2 mb-3">
-        <span>{icon}</span>
-        <h3 className="text-sm font-medium text-oh-text">{title}</h3>
+    <div id={sectionId} className={`${bgClass} border ${borderClass} rounded-lg p-4 scroll-mt-6`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span>{icon}</span>
+          <h3 className="text-sm font-medium text-oh-text">{title}</h3>
+        </div>
+        <SectionMenu id={sectionId} />
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { parseRunSlug, extractTriggeredBy, extractTriggerReason, extractCancelledBy, getRuntime, isFinished } from '../api'
 import type { RunMetadata } from '../api'
 import StatusTimeline from './StatusTimeline'
@@ -6,6 +6,8 @@ import JsonCard from './JsonCard'
 import CompletedRunResults from './CompletedRunResults'
 
 import ErrorReportSection from './ErrorReportSection'
+
+import SectionMenu from './SectionMenu'
 
 const BENCHMARK_COLORS: Record<string, string> = {
   swebench: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
@@ -24,6 +26,19 @@ interface RunDetailViewProps {
 
 export default function RunDetailView({ slug, metadata, loading, status }: RunDetailViewProps) {
   const parsed = parseRunSlug(slug)
+
+  useEffect(() => {
+    if (!loading && window.location.hash) {
+      // Give React a moment to render the newly un-hidden components
+      setTimeout(() => {
+        const id = window.location.hash.slice(1)
+        const el = document.getElementById(id)
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth' })
+        }
+      }, 100)
+    }
+  }, [loading])
 
   if (loading) {
     return (
@@ -82,36 +97,39 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
 
       {/* Cancelled Section */}
       {metadata?.cancelEval && (
-        <div data-testid="cancelled-section" className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-5">
-          <div className="flex items-start gap-3">
-            <span className="text-xl">🚫</span>
-            <div>
-              <h3 className="text-base font-semibold text-orange-400 mb-1">Evaluation Cancelled</h3>
-              <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-oh-text-muted">
-                {!!metadata.cancelEval.timestamp && (
-                  <span data-testid="cancelled-timestamp">
-                    <span className="font-medium">Cancelled at:</span>{' '}
-                    {new Date(metadata.cancelEval.timestamp as string).toLocaleString()}
+        <div id="cancelled-section" data-testid="cancelled-section" className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-5 scroll-mt-6">
+          <div className="flex items-start justify-between">
+            <div className="flex items-start gap-3">
+              <span className="text-xl">🚫</span>
+              <div>
+                <h3 className="text-base font-semibold text-orange-400 mb-1">Evaluation Cancelled</h3>
+                <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-oh-text-muted">
+                  {!!metadata.cancelEval.timestamp && (
+                    <span data-testid="cancelled-timestamp">
+                      <span className="font-medium">Cancelled at:</span>{' '}
+                      {new Date(metadata.cancelEval.timestamp as string).toLocaleString()}
+                    </span>
+                  )}
+                  <span data-testid="cancelled-by">
+                    <span className="font-medium">Cancelled by:</span>{' '}
+                    {extractCancelledBy(metadata.cancelEval)}
                   </span>
-                )}
-                <span data-testid="cancelled-by">
-                  <span className="font-medium">Cancelled by:</span>{' '}
-                  {extractCancelledBy(metadata.cancelEval)}
-                </span>
-                {metadata.cancelEval.kubernetes_jobs_found !== undefined && (
-                  <span data-testid="kubernetes-jobs-found">
-                    <span className="font-medium">Kubernetes jobs found:</span>{' '}
-                    {String(metadata.cancelEval.kubernetes_jobs_found)}
-                  </span>
-                )}
-                {metadata.cancelEval.helm_releases_found !== undefined && (
-                  <span data-testid="helm-releases-found">
-                    <span className="font-medium">Helm releases found:</span>{' '}
-                    {String(metadata.cancelEval.helm_releases_found)}
-                  </span>
-                )}
+                  {metadata.cancelEval.kubernetes_jobs_found !== undefined && (
+                    <span data-testid="kubernetes-jobs-found">
+                      <span className="font-medium">Kubernetes jobs found:</span>{' '}
+                      {String(metadata.cancelEval.kubernetes_jobs_found)}
+                    </span>
+                  )}
+                  {metadata.cancelEval.helm_releases_found !== undefined && (
+                    <span data-testid="helm-releases-found">
+                      <span className="font-medium">Helm releases found:</span>{' '}
+                      {String(metadata.cancelEval.helm_releases_found)}
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
+            <SectionMenu id="cancelled-section" />
           </div>
         </div>
       )}
@@ -157,8 +175,11 @@ function CancelEvaluationSection({ jobId }: { jobId: string }) {
   }
 
   return (
-    <div data-testid="cancel-evaluation-section" className="bg-oh-surface border border-oh-border rounded-lg p-5">
-      <h3 className="text-lg font-semibold text-oh-text mb-3">Cancel Evaluation</h3>
+    <div id="cancel-evaluation" data-testid="cancel-evaluation-section" className="bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-6">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold text-oh-text">Cancel Evaluation</h3>
+        <SectionMenu id="cancel-evaluation" />
+      </div>
       <button
         onClick={handleClick}
         className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-gray-600 hover:bg-gray-700 text-white transition-colors cursor-pointer"

--- a/frontend/src/components/SectionMenu.tsx
+++ b/frontend/src/components/SectionMenu.tsx
@@ -1,0 +1,69 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface SectionMenuProps {
+  id: string;
+}
+
+export default function SectionMenu({ id }: SectionMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleCopyLink = () => {
+    const url = new URL(window.location.href);
+    url.hash = id;
+    navigator.clipboard.writeText(url.toString());
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+      setIsOpen(false);
+    }, 1500);
+  };
+
+  return (
+    <div className="relative inline-block" ref={menuRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="p-1 text-oh-text-muted hover:text-oh-text hover:bg-oh-bg rounded transition-colors"
+        aria-label="Section options"
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z" />
+        </svg>
+      </button>
+      
+      {isOpen && (
+        <div className="absolute right-0 mt-1 w-36 bg-oh-surface border border-oh-border rounded shadow-lg z-10">
+          <button
+            onClick={handleCopyLink}
+            className="w-full text-left px-3 py-2 text-sm text-oh-text hover:bg-oh-bg hover:text-oh-primary transition-colors flex items-center gap-2"
+          >
+            {copied ? (
+              <>
+                <svg className="w-3.5 h-3.5 text-oh-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                <span>Copied!</span>
+              </>
+            ) : (
+              <>
+                <span>🔗</span>
+                <span>Copy link</span>
+              </>
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/StatusTimeline.tsx
+++ b/frontend/src/components/StatusTimeline.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import type { RunMetadata } from '../api'
 
+import SectionMenu from './SectionMenu'
+
 interface StatusTimelineProps {
   metadata: RunMetadata
   now?: number
@@ -55,8 +57,11 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
   }, [nowProp])
 
   return (
-    <div className="bg-oh-surface border border-oh-border rounded-lg p-5">
-      <h3 className="text-sm font-medium text-oh-text-muted mb-4">Pipeline Progress</h3>
+    <div id="pipeline-progress" className="bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-oh-text-muted">Pipeline Progress</h3>
+        <SectionMenu id="pipeline-progress" />
+      </div>
       <div className="flex items-center gap-0">
         {STAGES.map((stage, i) => {
           const startData = metadata[stage.startKey]


### PR DESCRIPTION
Fixes #65.

This PR implements the requested feature:
- Added a `...` button menu to each section in the detail page.
- The menu contains a "🔗 Copy link" option.
- Clicking the link copies the URL with the section's `#id`.
- Navigating to the URL with the hash automatically scrolls the page to that specific section (with proper top-margin padding and handles async component loading).
- Added test coverage for the `SectionMenu` component.