### PR TITLE
Fix section scroll offset when navigating via anchor links

### DIFF
--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -146,7 +146,7 @@ export default function CompletedRunResults({ slug }: CompletedRunResultsProps) 
 
   if (loading) {
     return (
-      <div id="run-results" className="bg-oh-surface border border-oh-success/30 rounded-lg p-4 scroll-mt-6">
+      <div id="run-results" className="bg-oh-surface border border-oh-success/30 rounded-lg p-4 scroll-mt-24">
         <div className="flex items-center gap-2 text-oh-text-muted text-sm">
           <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
@@ -161,7 +161,7 @@ export default function CompletedRunResults({ slug }: CompletedRunResultsProps) 
   if (!outputReport && !costReport) return null
 
   return (
-    <div id="run-results" className="space-y-4 scroll-mt-6">
+    <div id="run-results" className="space-y-4 scroll-mt-24">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold text-oh-text flex items-center gap-2">
           <span className="text-oh-success">✓</span> Run Results

--- a/frontend/src/components/ErrorReportSection.tsx
+++ b/frontend/src/components/ErrorReportSection.tsx
@@ -59,7 +59,7 @@ export default function ErrorReportSection({ slug }: ErrorReportSectionProps) {
   const icon = noErrors ? "✅" : "⚠️"
 
   return (
-    <div id="error-report" data-testid="error-report-section" className="col-span-1 lg:col-span-2 bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-6">
+    <div id="error-report" data-testid="error-report-section" className="col-span-1 lg:col-span-2 bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-24">
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2">
           <span className="text-xl">{icon}</span>

--- a/frontend/src/components/JsonCard.tsx
+++ b/frontend/src/components/JsonCard.tsx
@@ -12,7 +12,7 @@ export default function JsonCard({ title, data, icon, isError }: JsonCardProps) 
 
   if (data === null || data === undefined) {
     return (
-      <div id={sectionId} className="bg-oh-surface border border-oh-border rounded-lg p-4 opacity-50 scroll-mt-6">
+      <div id={sectionId} className="bg-oh-surface border border-oh-border rounded-lg p-4 opacity-50 scroll-mt-24">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
             <span>{icon}</span>
@@ -29,7 +29,7 @@ export default function JsonCard({ title, data, icon, isError }: JsonCardProps) 
   const bgClass = isError ? 'bg-oh-error/5' : 'bg-oh-surface'
 
   return (
-    <div id={sectionId} className={`${bgClass} border ${borderClass} rounded-lg p-4 scroll-mt-6`}>
+    <div id={sectionId} className={`${bgClass} border ${borderClass} rounded-lg p-4 scroll-mt-24`}>
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <span>{icon}</span>

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -97,7 +97,7 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
 
       {/* Cancelled Section */}
       {metadata?.cancelEval && (
-        <div id="cancelled-section" data-testid="cancelled-section" className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-5 scroll-mt-6">
+        <div id="cancelled-section" data-testid="cancelled-section" className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-5 scroll-mt-24">
           <div className="flex items-start justify-between">
             <div className="flex items-start gap-3">
               <span className="text-xl">🚫</span>
@@ -175,7 +175,7 @@ function CancelEvaluationSection({ jobId }: { jobId: string }) {
   }
 
   return (
-    <div id="cancel-evaluation" data-testid="cancel-evaluation-section" className="bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-6">
+    <div id="cancel-evaluation" data-testid="cancel-evaluation-section" className="bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-24">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-lg font-semibold text-oh-text">Cancel Evaluation</h3>
         <SectionMenu id="cancel-evaluation" />

--- a/frontend/src/components/StatusTimeline.tsx
+++ b/frontend/src/components/StatusTimeline.tsx
@@ -57,7 +57,7 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
   }, [nowProp])
 
   return (
-    <div id="pipeline-progress" className="bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-6">
+    <div id="pipeline-progress" className="bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-24">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-sm font-medium text-oh-text-muted">Pipeline Progress</h3>
         <SectionMenu id="pipeline-progress" />


### PR DESCRIPTION
This PR fixes a minor scrolling offset issue observed after the previous `#65` fix was merged.

When a user pasted a section link directly into their address bar, the browser would scroll the page right up to the top edge of the viewport. However, since the top header is sticky and takes up some space (`h-16`), the section title was partly obscured.

This patch updates the `scroll-mt` classes across all detail page sections from `scroll-mt-6` to `scroll-mt-24` (96px). Since the header is 64px tall, this ensures the content is clearly visible below the header with comfortable padding.