### PR TITLE
Make trigger_reason URLs clickable in the detail page

### DIFF
--- a/frontend/src/__tests__/JsonCardLinks.test.tsx
+++ b/frontend/src/__tests__/JsonCardLinks.test.tsx
@@ -68,3 +68,89 @@ describe('JsonCard repo links', () => {
     expect(screen.queryByRole('link')).toBeNull()
   })
 })
+
+describe('JsonCard URL detection', () => {
+  it('links trigger_reason when value is a full https URL', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ trigger_reason: 'https://github.com/OpenHands/foo/pull/42' }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'https://github.com/OpenHands/foo/pull/42' })
+    expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/foo/pull/42')
+    expect(link.getAttribute('target')).toBe('_blank')
+  })
+
+  it('links trigger_reason when value is a bare domain URL', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ trigger_reason: 'openhands.dev/blabla' }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'openhands.dev/blabla' })
+    expect(link.getAttribute('href')).toBe('https://openhands.dev/blabla')
+  })
+
+  it('links the URL portion when trigger_reason contains a URL embedded in text', () => {
+    const { container } = render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ trigger_reason: 'abc openhands.dev/blabla xyz' }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'openhands.dev/blabla' })
+    expect(link.getAttribute('href')).toBe('https://openhands.dev/blabla')
+    // surrounding text is preserved
+    const cell = container.querySelector('td:last-child')!
+    expect(cell.textContent).toBe('abc openhands.dev/blabla xyz')
+  })
+
+  it('links only the first URL when multiple URLs appear in a value', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ trigger_reason: 'https://first.example.com/a https://second.example.com/b' }}
+      />
+    )
+
+    const links = screen.getAllByRole('link')
+    // Only one link should be rendered (the first URL)
+    const triggerLinks = links.filter(l => l.closest('td'))
+    expect(triggerLinks).toHaveLength(1)
+    expect(triggerLinks[0].getAttribute('href')).toBe('https://first.example.com/a')
+  })
+
+  it('does not link plain text with no URL', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ trigger_reason: 'testing SDK: fix/issue-2375' }}
+      />
+    )
+
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('links any string field that is a URL, not just trigger_reason', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ some_url_field: 'https://example.com/path' }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'https://example.com/path' })
+    expect(link.getAttribute('href')).toBe('https://example.com/path')
+  })
+})

--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, within, fireEvent, act } from '@testing-library/react'
 import RunDetailView from '../components/RunDetailView'
 import type { RunMetadata } from '../api'
 
@@ -176,6 +176,57 @@ describe('RunDetailView', () => {
     )
     const el = screen.getByTestId('trigger-reason')
     expect(el.textContent).toContain('—')
+  })
+
+  it('renders trigger reason as a link when value is a full URL', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 'https://github.com/OpenHands/foo/pull/42' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('trigger-reason')
+    const link = within(el).getByRole('link', { name: 'https://github.com/OpenHands/foo/pull/42' })
+    expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/foo/pull/42')
+    expect(link.getAttribute('target')).toBe('_blank')
+  })
+
+  it('renders trigger reason as a link when value is a bare domain URL', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 'openhands.dev/blabla' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('trigger-reason')
+    const link = within(el).getByRole('link', { name: 'openhands.dev/blabla' })
+    expect(link.getAttribute('href')).toBe('https://openhands.dev/blabla')
+  })
+
+  it('renders only the URL portion as a link when trigger reason contains a URL in text', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 'abc openhands.dev/blabla xyz' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('trigger-reason')
+    const link = within(el).getByRole('link', { name: 'openhands.dev/blabla' })
+    expect(link.getAttribute('href')).toBe('https://openhands.dev/blabla')
+    expect(el.textContent).toContain('abc')
+    expect(el.textContent).toContain('xyz')
+  })
+
+  it('does not render a link when trigger reason has no URL', () => {
+    const metadata = makeMetadata({
+      params: { trigger_reason: 'testing SDK: fix/issue-2375' },
+    })
+    render(
+      <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="pending" />
+    )
+    const el = screen.getByTestId('trigger-reason')
+    expect(el.textContent).toContain('testing SDK: fix/issue-2375')
+    expect(within(el).queryByRole('link')).toBeNull()
   })
 
   it('shows dash for triggered by and runtime when metadata is null', () => {

--- a/frontend/src/components/JsonCard.tsx
+++ b/frontend/src/components/JsonCard.tsx
@@ -16,6 +16,15 @@ const BENCHMARKS_ACTIONS_BASE_URL = 'https://github.com/OpenHands/benchmarks/act
 
 const SHA_RE = /^[0-9a-f]{7,40}$/i
 const GIT_REFS_HEADS_PREFIX = 'refs/heads/'
+const URL_RE = /https?:\/\/[^\s<>"']+|[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}\/[^\s<>"']*/
+
+function findFirstUrl(text: string): { url: string; href: string; start: number; end: number } | null {
+  const m = URL_RE.exec(text)
+  if (!m) return null
+  const url = m[0].replace(/[.,;:!?)\]>]+$/, '')
+  const href = /^https?:\/\//.test(url) ? url : `https://${url}`
+  return { url, href, start: m.index, end: m.index + url.length }
+}
 
 export default function JsonCard({ title, data, icon, isError }: JsonCardProps) {
   const sectionId = title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
@@ -81,6 +90,22 @@ function formatValue(key: string, value: unknown): ReactNode {
   }
 
   if (typeof value === 'object') return JSON.stringify(value, null, 2)
+
+  if (typeof value === 'string') {
+    const urlMatch = findFirstUrl(value)
+    if (urlMatch) {
+      return (
+        <>
+          {value.slice(0, urlMatch.start)}
+          <a className="text-oh-primary hover:underline" href={urlMatch.href} target="_blank" rel="noreferrer">
+            {urlMatch.url}
+          </a>
+          {value.slice(urlMatch.end)}
+        </>
+      )
+    }
+  }
+
   return String(value)
 }
 

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -73,7 +73,7 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
             </div>
             <div className="mt-2 text-sm text-oh-text-muted">
               <span data-testid="trigger-reason">
-                <span className="font-medium">Trigger reason:</span> {triggerReason}
+                <span className="font-medium">Trigger reason:</span> {renderWithUrl(triggerReason)}
               </span>
             </div>
           </div>
@@ -163,6 +163,24 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
         <CancelEvaluationSection jobId={parsed.jobId} />
       )}
     </div>
+  )
+}
+
+const URL_RE = /https?:\/\/[^\s<>"']+|[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}\/[^\s<>"']*/
+
+function renderWithUrl(text: string) {
+  const m = URL_RE.exec(text)
+  if (!m) return text
+  const url = m[0].replace(/[.,;:!?)\]>]+$/, '')
+  const href = /^https?:\/\//.test(url) ? url : `https://${url}`
+  return (
+    <>
+      {text.slice(0, m.index)}
+      <a className="text-oh-primary hover:underline" href={href} target="_blank" rel="noreferrer">
+        {url}
+      </a>
+      {text.slice(m.index + url.length)}
+    </>
   )
 }
 


### PR DESCRIPTION
Fixes #73

## What

In the run detail page, if `trigger_reason` (or any metadata string value) is a URL or **contains** a URL embedded in surrounding text, it is now rendered as a clickable anchor tag.

Supported URL forms:
- Full URL: `https://github.com/OpenHands/foo/pull/42`
- Bare domain+path: `openhands.dev/blabla`
- URL inside text: `"abc openhands.dev/blabla xyz"` → `abc` + link + `xyz`

When multiple URLs are present, only the first is linked.

## Where it applies (both places on the detail page)

1. **Header "Trigger reason:" field** — `RunDetailView` now calls `renderWithUrl()` on the extracted reason string.
2. **Parameters / Init JSON cards** — `JsonCard`'s `formatValue()` now falls back to `findFirstUrl()` for any string value not already handled by a specific key rule (SDK commit, branch links, etc.).

## Implementation

- `JsonCard.tsx`: added `URL_RE` regex, `findFirstUrl()` helper, and a URL-linkify fallback path in `formatValue()`.
- `RunDetailView.tsx`: added `renderWithUrl()` helper (same regex logic) used in the header section.

## Tests

- **`JsonCardLinks.test.tsx`**: 6 new tests covering full URL, bare domain URL, URL-in-text, first-URL-only, plain text (no match), and generic field linkification.
- **`RunDetailView.test.tsx`**: 4 new tests covering the header section for full URL, bare domain URL, URL-in-text, and plain text cases.

All 202 tests pass.