### PR TITLE
feat: show submission badge when metadata/submission.json exists

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, within, fireEvent, act } from '@testing-library/react'
 import RunDetailView from '../components/RunDetailView'
 import type { RunMetadata } from '../api'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
 
 function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
   return {
@@ -578,6 +585,47 @@ describe('RunDetailView', () => {
       expect(k8sEl.textContent).toContain('2')
       const helmEl = screen.getByTestId('helm-releases-found')
       expect(helmEl.textContent).toContain('4')
+    })
+  })
+
+  describe('Submission badge', () => {
+    it('shows submission badge with PR link when submission.json exists', async () => {
+      globalThis.fetch = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => ({
+          timestamp: '2026-03-23T21:29:48Z',
+          url: 'https://github.com/OpenHands/openhands-index-results/pull/719',
+        }),
+      })) as unknown as typeof fetch
+
+      render(
+        <RunDetailView slug={defaultSlug} metadata={null} loading={false} status="pending" />
+      )
+
+      const badge = await screen.findByTestId('submission-badge')
+      expect(badge.textContent).toContain('Submitted to OpenHands Index')
+      expect(badge.getAttribute('href')).toBe('https://github.com/OpenHands/openhands-index-results/pull/719')
+      expect(badge.getAttribute('target')).toBe('_blank')
+    })
+
+    it('does not show submission badge when submission.json does not exist', async () => {
+      globalThis.fetch = vi.fn(async () => ({
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+      })) as unknown as typeof fetch
+
+      render(
+        <RunDetailView slug={defaultSlug} metadata={null} loading={false} status="pending" />
+      )
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 50))
+      })
+
+      expect(screen.queryByTestId('submission-badge')).toBeNull()
     })
   })
 })

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange } from '../api'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData } from '../api'
 import type { RunMetadata } from '../api'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
 
 describe('getResultsUrl', () => {
   it('constructs the correct URL for a file', () => {
@@ -282,5 +289,89 @@ describe('getDatesForRange', () => {
       '2025-03-01',
       '2025-02-28',
     ])
+  })
+})
+
+describe('fetchSubmissionData', () => {
+  it('returns submission data when file exists with valid url and timestamp', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({
+        timestamp: '2026-03-23T21:29:48Z',
+        url: 'https://github.com/OpenHands/openhands-index-results/pull/719',
+      }),
+    })) as unknown as typeof fetch
+
+    const result = await fetchSubmissionData('swebench/model/123')
+    expect(result).toEqual({
+      timestamp: '2026-03-23T21:29:48Z',
+      url: 'https://github.com/OpenHands/openhands-index-results/pull/719',
+    })
+  })
+
+  it('returns null when submission.json does not exist (404)', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+    })) as unknown as typeof fetch
+
+    const result = await fetchSubmissionData('swebench/model/123')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when response has no url field', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ timestamp: '2026-03-23T21:29:48Z' }),
+    })) as unknown as typeof fetch
+
+    const result = await fetchSubmissionData('swebench/model/123')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when response has non-string url field', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ url: 42 }),
+    })) as unknown as typeof fetch
+
+    const result = await fetchSubmissionData('swebench/model/123')
+    expect(result).toBeNull()
+  })
+
+  it('strips trailing slash from slug when building fetch URL', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+    })) as unknown as typeof fetch
+    globalThis.fetch = fetchMock
+
+    await fetchSubmissionData('swebench/model/123/')
+    const calledUrl = String((fetchMock as ReturnType<typeof vi.fn>).mock.calls[0][0])
+    expect(calledUrl).not.toMatch(/\/\//  )
+    expect(calledUrl).toContain('swebench/model/123/metadata/submission.json')
+  })
+
+  it('uses empty string for timestamp when not a string in the response', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ url: 'https://github.com/OpenHands/results/pull/1', timestamp: null }),
+    })) as unknown as typeof fetch
+
+    const result = await fetchSubmissionData('swebench/model/123')
+    expect(result).toEqual({
+      timestamp: '',
+      url: 'https://github.com/OpenHands/results/pull/1',
+    })
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -304,3 +304,18 @@ export async function fetchErrorReport(slug: string): Promise<string | null> {
     return null
   }
 }
+
+export interface SubmissionData {
+  timestamp: string
+  url: string
+}
+
+export async function fetchSubmissionData(slug: string): Promise<SubmissionData | null> {
+  const cleanSlug = slug.replace(/\/$/, '')
+  const data = await fetchJson(`${BASE_URL}/${cleanSlug}/metadata/submission.json`)
+  if (!data || typeof data.url !== 'string') return null
+  return {
+    timestamp: typeof data.timestamp === 'string' ? data.timestamp : '',
+    url: data.url,
+  }
+}

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
-import { parseRunSlug, extractTriggeredBy, extractTriggerReason, extractCancelledBy, getRuntime, isFinished } from '../api'
-import type { RunMetadata } from '../api'
+import { parseRunSlug, extractTriggeredBy, extractTriggerReason, extractCancelledBy, getRuntime, isFinished, fetchSubmissionData } from '../api'
+import type { RunMetadata, SubmissionData } from '../api'
 import StatusTimeline from './StatusTimeline'
 import JsonCard from './JsonCard'
 import CompletedRunResults from './CompletedRunResults'
@@ -26,6 +26,11 @@ interface RunDetailViewProps {
 
 export default function RunDetailView({ slug, metadata, loading, status }: RunDetailViewProps) {
   const parsed = parseRunSlug(slug)
+  const [submission, setSubmission] = useState<SubmissionData | null>(null)
+
+  useEffect(() => {
+    fetchSubmissionData(slug).then(setSubmission)
+  }, [slug])
 
   useEffect(() => {
     if (!loading && window.location.hash) {
@@ -66,7 +71,20 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
         <div className="flex items-start justify-between gap-4">
           {/* Left: model, benchmark + job id, trigger reason */}
           <div className="min-w-0">
-            <h2 className="text-xl font-semibold text-oh-text">{parsed.model}</h2>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h2 className="text-xl font-semibold text-oh-text">{parsed.model}</h2>
+              {submission && (
+                <a
+                  href={submission.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  data-testid="submission-badge"
+                  className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-500/20 text-yellow-400 border border-yellow-500/30 hover:bg-yellow-500/30 transition-colors"
+                >
+                  🏅 Submitted to OpenHands Index
+                </a>
+              )}
+            </div>
             <div className="flex items-center gap-2 mt-2 flex-wrap">
               <BenchmarkBadge name={parsed.benchmark} />
               {parsed.jobId && <CopyJobId jobId={parsed.jobId} />}


### PR DESCRIPTION
## Summary

Fixes #75

Reads `metadata/submission.json` for each run and displays a **🏅 Submitted to OpenHands Index** badge next to the model title in the run detail page when the file is present. The badge links to the PR URL from `submission.json`.

### Example

For a run like `swebenchmultimodal/litellm_proxy-minimax-MiniMax-M2-7/23369175877`, if `metadata/submission.json` contains:
```json
{
  "timestamp": "2026-03-23T21:29:48Z",
  "url": "https://github.com/OpenHands/openhands-index-results/pull/719"
}
```
the badge will appear next to the model name and link to the PR.

## Changes

- **`frontend/src/api.ts`**: Added `SubmissionData` interface and `fetchSubmissionData(slug)` function that fetches and parses `metadata/submission.json`
- **`frontend/src/components/RunDetailView.tsx`**: Fetches submission data on slug change and renders the badge as an anchor link next to the model title
- **`frontend/src/__tests__/api.test.ts`**: Unit tests for `fetchSubmissionData` (valid response, 404, missing/invalid url, empty timestamp, trailing slash)
- **`frontend/src/__tests__/RunDetailView.test.tsx`**: Component tests for submission badge display and absence

## Tests

All 210 tests pass (`make test`).