### PR TITLE
Link sdk_workflow_run_id to GitHub Actions run

### DIFF
--- a/frontend/src/__tests__/JsonCardLinks.test.tsx
+++ b/frontend/src/__tests__/JsonCardLinks.test.tsx
@@ -17,6 +17,31 @@ describe('JsonCard repo links', () => {
     expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/software-agent-sdk/commit/abc1234def5678')
   })
 
+  it('links sdk_workflow_run_id to the software-agent-sdk actions run page', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ sdk_workflow_run_id: '23663720332' }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: '23663720332' })
+    expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/software-agent-sdk/actions/runs/23663720332')
+  })
+
+  it('does not link sdk_workflow_run_id if value is not numeric', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ sdk_workflow_run_id: 'not-a-number' }}
+      />
+    )
+
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
   it('links evaluation_branch to the evaluation repo tree and strips refs/heads/', () => {
     render(
       <JsonCard

--- a/frontend/src/components/JsonCard.tsx
+++ b/frontend/src/components/JsonCard.tsx
@@ -10,6 +10,7 @@ interface JsonCardProps {
 }
 
 const SDK_COMMIT_BASE_URL = 'https://github.com/OpenHands/software-agent-sdk/commit/'
+const SDK_WORKFLOW_RUN_BASE_URL = 'https://github.com/OpenHands/software-agent-sdk/actions/runs/'
 const EVAL_BRANCH_BASE_URL = 'https://github.com/OpenHands/evaluation/tree/'
 const BENCHMARKS_BRANCH_BASE_URL = 'https://github.com/OpenHands/benchmarks/tree/'
 const BENCHMARKS_ACTIONS_BASE_URL = 'https://github.com/OpenHands/benchmarks/actions'
@@ -120,6 +121,10 @@ function getLinkForKeyValue(key: string, value: unknown): { href: string; text: 
 
   if (keyLower.includes('sdk_commit') && SHA_RE.test(value)) {
     return { href: `${SDK_COMMIT_BASE_URL}${value}`, text: value }
+  }
+
+  if (keyLower.includes('sdk_workflow_run_id') && /^\d+$/.test(value)) {
+    return { href: `${SDK_WORKFLOW_RUN_BASE_URL}${value}`, text: value }
   }
 
   if (keyLower.includes('evaluation_branch') || keyLower.includes('eval_branch')) {


### PR DESCRIPTION
## Description
This PR implements a fix for issue #86 by making `sdk_workflow_run_id` values in params.json clickable links to the corresponding GitHub Actions workflow run.

## Changes
- Added `SDK_WORKFLOW_RUN_BASE_URL` constant for the GitHub Actions runs URL
- Extended `getLinkForKeyValue()` function to handle `sdk_workflow_run_id` field
- The value is validated to be numeric (matching workflow run ID format) before creating a link
- Links point to `https://github.com/OpenHands/software-agent-sdk/actions/runs/{sdk_workflow_run_id}`

## Tests
- Added test case verifying that numeric `sdk_workflow_run_id` values are correctly linked
- Added test case ensuring non-numeric values are not linked
- All existing tests continue to pass (250/250 tests passing)

## Example
When `sdk_workflow_run_id: "23663720332"` appears in params.json:
- **Before**: Displays as plain text `23663720332`
- **After**: Displays as clickable link `23663720332` → `https://github.com/OpenHands/software-agent-sdk/actions/runs/23663720332`

Fixes #86