### PR TITLE
Fix: change model_id to model_ids in copied command

### DIFF
--- a/frontend/src/components/CopyCommandButton.test.tsx
+++ b/frontend/src/components/CopyCommandButton.test.tsx
@@ -72,7 +72,7 @@ describe('CopyCommandButton', () => {
     expect(call).toContain('-f sdk_ref=""')
     expect(call).toContain('-f allow_unreleased_branches="true"')
     expect(call).toContain('-f eval_limit="1"')
-    expect(call).toContain('-f model_id="minimax-m2.5"')
+    expect(call).toContain('-f model_ids="minimax-m2.5"')
     expect(call).toContain('-f reason="test eval-job-id"')
     expect(call).toContain('-f eval_branch="main"')
     expect(call).toContain('-f benchmarks_branch="main"')
@@ -125,7 +125,7 @@ describe('CopyCommandButton', () => {
     fireEvent.click(copyButton)
 
     const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(call).toContain('-f model_id="claude-sonnet-4-5-20250929"')
+    expect(call).toContain('-f model_ids="claude-sonnet-4-5-20250929"')
   })
 
   it('strips refs/heads/ from branches', () => {

--- a/frontend/src/components/CopyCommandButton.tsx
+++ b/frontend/src/components/CopyCommandButton.tsx
@@ -36,8 +36,8 @@ function extractWorkflowInputs(data: Record<string, unknown>): Record<string, st
   // eval_limit
   params['eval_limit'] = valueToString(data.eval_limit)
 
-  // model_id (must exist in params, don't extract from model_name)
-  params['model_id'] = valueToString(data.model_id)
+  // model_ids (must exist in params, don't extract from model_name)
+  params['model_ids'] = valueToString(data.model_id)
 
   // reason (from trigger_reason)
   params['reason'] = valueToString(data.trigger_reason)


### PR DESCRIPTION
## Summary

The copied gh workflow command was using `model_id` (singular) as the parameter name, but it should be `model_ids` (plural).

This is a minimal fix that changes only the field name in the generated command - the value extraction remains unchanged.

## Changes

- Changed `params['model_id']` to `params['model_ids']` in `CopyCommandButton.tsx`
- Updated tests to expect `model_ids` instead of `model_id`

## Testing

All 9 tests in `CopyCommandButton.test.tsx` pass.

Fixes #92

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2383b23c-e00f-4eaf-8973-dae8d897d36d)