### PR TITLE
Add 'Active' status filter to filter runs by non-terminal statuses

### DIFF
--- a/frontend/src/__tests__/RunListView.test.tsx
+++ b/frontend/src/__tests__/RunListView.test.tsx
@@ -195,4 +195,90 @@ describe('RunListView', () => {
       expect(screen.getByText('No runs match the current filters.')).toBeInTheDocument()
     })
   })
+
+  describe('active status filtering', () => {
+    const createMetadata = (status: string) => {
+      const base = {
+        init: null,
+        params: null,
+        error: null,
+        runInferStart: null,
+        runInferEnd: null,
+        evalInferStart: null,
+        evalInferEnd: null,
+        cancelEval: null
+      }
+      switch (status) {
+        case 'pending':
+          return { ...base }
+        case 'building':
+          return { ...base, params: { timestamp: '2025-01-01T00:00:00Z' } }
+        case 'running-infer':
+          return { ...base, runInferStart: { timestamp: '2025-01-01T00:00:00Z' } }
+        case 'running-eval':
+          return { ...base, evalInferStart: { timestamp: '2025-01-01T00:00:00Z' } }
+        case 'completed':
+          return { ...base, evalInferEnd: { timestamp: '2025-01-01T00:00:00Z' } }
+        case 'error':
+          return { ...base, error: { timestamp: '2025-01-01T00:00:00Z' } }
+        case 'cancelled':
+          return { ...base, cancelEval: { timestamp: '2025-01-01T00:00:00Z' } }
+        default:
+          return base
+      }
+    }
+
+    const activeStatusProps = {
+      runs: [
+        { slug: 'swebench/pending-run/1', benchmark: 'swebench', model: 'pending-run', jobId: '1' },
+        { slug: 'swebench/building-run/2', benchmark: 'swebench', model: 'building-run', jobId: '2' },
+        { slug: 'swebench/infer-run/3', benchmark: 'swebench', model: 'infer-run', jobId: '3' },
+        { slug: 'swebench/eval-run/4', benchmark: 'swebench', model: 'eval-run', jobId: '4' },
+        { slug: 'swebench/completed-run/5', benchmark: 'swebench', model: 'completed-run', jobId: '5' },
+        { slug: 'swebench/error-run/6', benchmark: 'swebench', model: 'error-run', jobId: '6' },
+        { slug: 'swebench/cancelled-run/7', benchmark: 'swebench', model: 'cancelled-run', jobId: '7' }
+      ],
+      loading: false,
+      error: null,
+      onSelectRun: mockOnSelectRun,
+      runMetadataMap: {
+        'swebench/pending-run/1': createMetadata('pending'),
+        'swebench/building-run/2': createMetadata('building'),
+        'swebench/infer-run/3': createMetadata('running-infer'),
+        'swebench/eval-run/4': createMetadata('running-eval'),
+        'swebench/completed-run/5': createMetadata('completed'),
+        'swebench/error-run/6': createMetadata('error'),
+        'swebench/cancelled-run/7': createMetadata('cancelled')
+      },
+      loadingMetadataList: false,
+      dayGroups: [{ date: '2025-01-01', runs: ['swebench/pending-run/1', 'swebench/building-run/2', 'swebench/infer-run/3', 'swebench/eval-run/4', 'swebench/completed-run/5', 'swebench/error-run/6', 'swebench/cancelled-run/7'] }],
+      filterBenchmark: 'all',
+      setFilterBenchmark: vi.fn(),
+      filterStatus: 'all',
+      setFilterStatus: vi.fn(),
+      filterText: '',
+      setFilterText: vi.fn()
+    }
+
+    it('shows all active statuses when filterStatus is "active"', () => {
+      render(<RunListView {...activeStatusProps} filterStatus="active" />)
+      // Should show pending, building, running-infer, running-eval
+      expect(screen.getByText('pending-run')).toBeInTheDocument()
+      expect(screen.getByText('building-run')).toBeInTheDocument()
+      expect(screen.getByText('infer-run')).toBeInTheDocument()
+      expect(screen.getByText('eval-run')).toBeInTheDocument()
+      // Should NOT show completed, error, cancelled
+      expect(screen.queryByText('completed-run')).not.toBeInTheDocument()
+      expect(screen.queryByText('error-run')).not.toBeInTheDocument()
+      expect(screen.queryByText('cancelled-run')).not.toBeInTheDocument()
+    })
+
+    it('shows the active option in the status filter dropdown', () => {
+      render(<RunListView {...activeStatusProps} />)
+      // The status dropdown is the second select element
+      const selects = document.querySelectorAll('select')
+      expect(selects[1]).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Active' })).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -165,7 +165,15 @@ export default function RunListView({
   const filteredRuns = useMemo(() => {
     return runsWithStatus.filter(run => {
       if (filterBenchmark !== 'all' && run.benchmark !== filterBenchmark) return false
-      if (filterStatus !== 'all' && run.status !== filterStatus) return false
+      if (filterStatus !== 'all') {
+        if (filterStatus === 'active') {
+          // Active status: show all non-terminal statuses (pending, building, running-infer, running-eval)
+          const activeStatuses: StatusType[] = ['pending', 'building', 'running-infer', 'running-eval']
+          if (!activeStatuses.includes(run.status)) return false
+        } else if (run.status !== filterStatus) {
+          return false
+        }
+      }
       if (filterText) {
         // Split by whitespace or + and filter out empty strings
         const searchTerms = filterText.toLowerCase().split(/[\s+]+/).filter(term => term.length > 0)
@@ -286,6 +294,7 @@ export default function RunListView({
           className="bg-oh-surface border border-oh-border rounded-lg px-3 py-1.5 text-sm text-oh-text focus:outline-none focus:ring-1 focus:ring-oh-primary"
         >
           <option value="all">All statuses</option>
+          <option value="active">Active</option>
           {statuses.map(s => (
             <option key={s} value={s}>{STATUS_CONFIG[s as StatusType]?.label || s}</option>
           ))}


### PR DESCRIPTION
## Summary

This PR adds an 'Active' option to the status filter dropdown in the run list view that shows all runs with statuses that are not terminal (not cancelled, error, or completed).

### Changes

- Added 'Active' option to the status filter dropdown
- Updated the filtering logic to include 'pending', 'building', 'running-infer', and 'running-eval' statuses when 'Active' is selected
- Added tests to verify the filtering behavior

### Technical Details

The active statuses represent runs that are still in progress:
- `pending`: Run has been initialized but not yet started building
- `building`: Docker images are being built
- `running-infer`: Inference is in progress
- `running-eval`: Evaluation is in progress

These are all non-terminal statuses that indicate a run is still active.

## Testing

- Added unit tests for the 'Active' status filter
- All 261 tests pass

## Checklist

- [x] Tests added/updated
- [x] Code follows project conventions
- [x] Tested locally

---

Fixes #94

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c9667e62-5eed-4b1b-9259-36050e51ff0d)