### PR TITLE
Cache all JSON files for faster filtering

### DIFF
--- a/frontend/src/__tests__/CompletedRunResults.test.tsx
+++ b/frontend/src/__tests__/CompletedRunResults.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import CompletedRunResults from '../components/CompletedRunResults'
+import { clearJsonCache } from '../api'
 
 const originalFetch = globalThis.fetch
 
@@ -50,6 +51,7 @@ function mockFetchWithCost(totalCost: number) {
 afterEach(() => {
   globalThis.fetch = originalFetch
   vi.restoreAllMocks()
+  clearJsonCache()
 })
 
 describe('CompletedRunResults', () => {

--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, within, fireEvent, act } from '@testing-library/react'
 import RunDetailView from '../components/RunDetailView'
 import type { RunMetadata } from '../api'
+import { clearJsonCache } from '../api'
 
 const originalFetch = globalThis.fetch
 
 afterEach(() => {
   globalThis.fetch = originalFetch
   vi.restoreAllMocks()
+  clearJsonCache()
 })
 
 function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport } from '../api'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, clearJsonCache } from '../api'
 import type { RunMetadata } from '../api'
 
 const originalFetch = globalThis.fetch
@@ -7,6 +7,7 @@ const originalFetch = globalThis.fetch
 afterEach(() => {
   globalThis.fetch = originalFetch
   vi.restoreAllMocks()
+  clearJsonCache()
 })
 
 describe('getResultsUrl', () => {

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   getRuntime,
   getStartTimestamp,
@@ -8,6 +8,8 @@ import {
   getStageStatus,
   extractCancelledBy,
   augmentParams,
+  clearJsonCache,
+  fetchJson,
 } from './api'
 import type { RunMetadata } from './api'
 
@@ -384,5 +386,61 @@ describe('augmentParams', () => {
   it('returns params unchanged when github_run_id is not a string', () => {
     const params = { sdk_commit: 'abc', github_run_id: 12345 }
     expect(augmentParams(params)).toBe(params)
+  })
+})
+
+describe('JSON caching', () => {
+  beforeEach(() => {
+    clearJsonCache()
+  })
+
+  it('clearJsonCache clears the internal cache', () => {
+    clearJsonCache()
+  })
+
+  it('fetchJson caches results by URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Map([['content-type', 'application/json']]),
+      json: () => Promise.resolve({ foo: 'bar' }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const url = '/test/metadata/init.json'
+
+    const result1 = await fetchJson(url)
+    expect(result1).toEqual({ foo: 'bar' })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    const result2 = await fetchJson(url)
+    expect(result2).toEqual({ foo: 'bar' })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    clearJsonCache()
+    const result3 = await fetchJson(url)
+    expect(result3).toEqual({ foo: 'bar' })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+
+    vi.restoreAllMocks()
+  })
+
+  it('fetchJson caches null results for failed requests', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const url = '/test/metadata/missing.json'
+
+    const result1 = await fetchJson(url)
+    expect(result1).toBeNull()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    const result2 = await fetchJson(url)
+    expect(result2).toBeNull()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    vi.restoreAllMocks()
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,12 @@
 const BASE_URL = '/api'
 const RESULTS_BASE_URL = 'https://results.eval.all-hands.dev'
 
+const jsonCache = new Map<string, Record<string, unknown> | null>()
+
+export function clearJsonCache(): void {
+  jsonCache.clear()
+}
+
 export async function fetchRunList(date: string): Promise<string[]> {
   const cacheBust = Math.floor(Date.now() / 1000)
   const res = await fetch(`${BASE_URL}/metadata/${date}.txt?${cacheBust}`)
@@ -72,14 +78,25 @@ const METADATA_FILES = [
   ['cancelEval', 'cancel-eval.json'],
 ] as const
 
-async function fetchJson(url: string): Promise<Record<string, unknown> | null> {
+export async function fetchJson(url: string): Promise<Record<string, unknown> | null> {
+  const cached = jsonCache.get(url)
+  if (cached !== undefined) return cached
   try {
     const res = await fetch(url)
-    if (!res.ok) return null
+    if (!res.ok) {
+      jsonCache.set(url, null)
+      return null
+    }
     const contentType = res.headers.get('content-type') || ''
-    if (contentType.includes('xml')) return null
-    return await res.json()
+    if (contentType.includes('xml')) {
+      jsonCache.set(url, null)
+      return null
+    }
+    const data = await res.json()
+    jsonCache.set(url, data)
+    return data
   } catch {
+    jsonCache.set(url, null)
     return null
   }
 }


### PR DESCRIPTION
## Summary

Fixes #96 - Cache all JSON files so that filtering is fast.

### Changes

- Add an in-memory cache (Map) for JSON files in `api.ts`
- Modify `fetchJson` to check cache before making network requests
- Cache both successful results and null values (for failed requests)
- Keep `.txt` files loading in real-time with cache-busting (as requested in the issue)
- Add `clearJsonCache()` function for testing purposes
- Export `fetchJson` for testing purposes
- Update all tests to clear cache between tests

### Benefits

- JSON files are not updated once written, so caching them is safe
- Filtering becomes faster because repeated accesses to the same JSON file dont trigger network requests
- The run list (`.txt` files) still loads in real-time, ensuring up-to-date information about new runs

### Testing

- All 264 tests pass