### PR TITLE
Add warning when eval started but error report not available yet

### DIFF
--- a/frontend/src/__tests__/ErrorReportSection.test.tsx
+++ b/frontend/src/__tests__/ErrorReportSection.test.tsx
@@ -18,12 +18,69 @@ describe('ErrorReportSection', () => {
     vi.clearAllMocks()
   })
 
-  it('does not render when error report is null', async () => {
+  it('does not render when error report is null and status is not eval-related', async () => {
+    vi.mocked(api.fetchErrorReport).mockResolvedValue(null)
+    
+    render(<ErrorReportSection slug="test-run" status="pending" />)
+    
+    await waitFor(() => {
+      expect(screen.queryByTestId('error-report-section')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not render when error report is null and no status provided', async () => {
     vi.mocked(api.fetchErrorReport).mockResolvedValue(null)
     
     render(<ErrorReportSection slug="test-run" />)
     
-    // Wait for the state to settle
+    await waitFor(() => {
+      expect(screen.queryByTestId('error-report-section')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows warning when eval started but error report not available yet (running-eval)', async () => {
+    vi.mocked(api.fetchErrorReport).mockResolvedValue(null)
+    
+    render(<ErrorReportSection slug="test-run" status="running-eval" />)
+    
+    await waitFor(() => {
+      expect(screen.getByTestId('error-report-section')).toBeInTheDocument()
+    })
+    
+    expect(screen.getByText('⏳')).toBeInTheDocument()
+    expect(screen.getByText('Error Report')).toBeInTheDocument()
+    expect(screen.getByText('Evaluation has started but error report is not available yet. Please check back shortly.')).toBeInTheDocument()
+  })
+
+  it('shows warning when eval started but error report not available yet (completed)', async () => {
+    vi.mocked(api.fetchErrorReport).mockResolvedValue(null)
+    
+    render(<ErrorReportSection slug="test-run" status="completed" />)
+    
+    await waitFor(() => {
+      expect(screen.getByTestId('error-report-section')).toBeInTheDocument()
+    })
+    
+    expect(screen.getByText('⏳')).toBeInTheDocument()
+    expect(screen.getByText('Error Report')).toBeInTheDocument()
+    expect(screen.getByText('Evaluation has started but error report is not available yet. Please check back shortly.')).toBeInTheDocument()
+  })
+
+  it('does not show warning when eval has not started (running-infer)', async () => {
+    vi.mocked(api.fetchErrorReport).mockResolvedValue(null)
+    
+    render(<ErrorReportSection slug="test-run" status="running-infer" />)
+    
+    await waitFor(() => {
+      expect(screen.queryByTestId('error-report-section')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not show warning when status is pending', async () => {
+    vi.mocked(api.fetchErrorReport).mockResolvedValue(null)
+    
+    render(<ErrorReportSection slug="test-run" status="pending" />)
+    
     await waitFor(() => {
       expect(screen.queryByTestId('error-report-section')).not.toBeInTheDocument()
     })

--- a/frontend/src/components/ErrorReportSection.tsx
+++ b/frontend/src/components/ErrorReportSection.tsx
@@ -5,6 +5,7 @@ import SectionMenu from './SectionMenu'
 
 interface ErrorReportSectionProps {
   slug: string
+  status?: 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
 }
 
 function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
@@ -23,7 +24,7 @@ function ExternalLink({ href, children }: { href: string; children: React.ReactN
   )
 }
 
-export default function ErrorReportSection({ slug }: ErrorReportSectionProps) {
+export default function ErrorReportSection({ slug, status }: ErrorReportSectionProps) {
   const [errorReport, setErrorReport] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -50,7 +51,32 @@ export default function ErrorReportSection({ slug }: ErrorReportSectionProps) {
     }
   }, [loading, errorReport])
 
-  if (loading || !errorReport) return null
+  const isEvalStarted = status === 'running-eval' || status === 'completed'
+
+  if (loading) return null
+
+  if (!errorReport) {
+    if (isEvalStarted) {
+      return (
+        <div id="error-report" data-testid="error-report-section" className="col-span-1 lg:col-span-2 bg-oh-surface border border-oh-border rounded-lg p-5 scroll-mt-24">
+          <div className="flex items-center justify-between mb-1">
+            <div className="flex items-center gap-2">
+              <span className="text-xl">⏳</span>
+              <h3 className="text-lg font-semibold text-oh-text">Error Report</h3>
+            </div>
+            <SectionMenu id="error-report" />
+          </div>
+          <div className="flex items-center gap-2 text-sm text-oh-warning mt-2">
+            <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <span>Evaluation has started but error report is not available yet. Please check back shortly.</span>
+          </div>
+        </div>
+      )
+    }
+    return null
+  }
 
   const errorsUrl = getResultsUrl(slug, 'conversation-errors.txt')
 

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -170,7 +170,7 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
 
       {/* Metadata Cards */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <ErrorReportSection slug={slug} />
+        <ErrorReportSection slug={slug} status={status} />
         <ParametersCard data={metadata?.params} />
         <JsonCard title="Init" data={metadata?.init} icon="🚀" />
         <JsonCard title="Run Infer Start" data={metadata?.runInferStart} icon="▶️" />


### PR DESCRIPTION
## Summary

Fixes #98 - Add warning when eval stage started but no error report yet

When the evaluation stage has started (status is 'running-eval' or 'completed') but there is no error report available yet, the UI now displays a warning message indicating that the error report is not available and to check back shortly.

## Changes

- **ErrorReportSection.tsx**: Added `status` prop and logic to show a warning message (with clock icon ⏳) when the eval has started but no error report is available
- **RunDetailView.tsx**: Pass the `status` prop to `ErrorReportSection`
- **ErrorReportSection.test.tsx**: Added tests for the new warning functionality

## Testing

All 266 tests pass including 8 new tests for the warning functionality:
- Shows warning when eval started but error report not available yet (running-eval)
- Shows warning when eval started but error report not available yet (completed)
- Does not show warning when eval has not started (running-infer)
- Does not show warning when status is pending

## Screenshots

The warning displays as:
- Icon: ⏳ (clock)
- Title: "Error Report"
- Message: "Evaluation has started but error report is not available yet. Please check back shortly."


@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d9085c6b-40b9-4795-b394-84b6e6734e5d)