### PR TITLE
Fix: Logo click should preserve filters like back button

### DIFF
--- a/frontend/src/__tests__/Header.test.tsx
+++ b/frontend/src/__tests__/Header.test.tsx
@@ -32,13 +32,35 @@ describe('Header', () => {
     expect(screen.getByText('OpenHands Eval Monitor')).toBeTruthy()
   })
 
-  it('renders the logo as a link when selectedRun is set', () => {
+  it('renders the logo as a button when selectedRun is set', () => {
     const props = { ...defaultProps, selectedRun: 'test-run-123' }
     render(<Header {...props} />)
     const logoContainer = screen.getByTestId('openhands-logo').parentElement
-    expect(logoContainer?.tagName).toBe('A')
+    expect(logoContainer?.tagName).toBe('BUTTON')
     expect(logoContainer?.className).toContain('cursor-pointer')
-    expect((logoContainer as HTMLAnchorElement).href).toContain('/')
+  })
+
+  it('calls onBack when logo button is clicked', () => {
+    const onBack = vi.fn()
+    const props = { ...defaultProps, selectedRun: 'test-run-123', onBack }
+    render(<Header {...props} />)
+    const logoButton = screen.getByTestId('openhands-logo').parentElement
+    logoButton?.click()
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens in new tab when logo button is ctrl/cmd+clicked', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const props = { ...defaultProps, selectedRun: 'test-run-123' }
+    render(<Header {...props} />)
+    const logoButton = screen.getByTestId('openhands-logo').parentElement as HTMLButtonElement
+    logoButton?.click()
+    // Simulate Ctrl+click
+    const ctrlClickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+    Object.defineProperty(ctrlClickEvent, 'ctrlKey', { value: true })
+    logoButton?.dispatchEvent(ctrlClickEvent)
+    expect(openSpy).toHaveBeenCalledWith('/', '_blank')
+    openSpy.mockRestore()
   })
 
   it('logo is not a link when selectedRun is not set', () => {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -39,8 +39,14 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
               </button>
             )}
             {selectedRun ? (
-              <a
-                href="/"
+              <button
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey) {
+                    window.open('/', '_blank')
+                  } else {
+                    onBack()
+                  }
+                }}
                 className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
                 title="Back to run list"
               >
@@ -53,7 +59,7 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
                 <h1 className="text-lg font-semibold text-oh-text hidden sm:block">
                   OpenHands Eval Monitor
                 </h1>
-              </a>
+              </button>
             ) : (
               <div className="flex items-center gap-2">
                 <img


### PR DESCRIPTION
## Summary

This PR fixes issue #108: "Pressing back and pressing the logo should be the same behavior."

### Changes Made

1. **Header.tsx**: Changed the logo from an anchor (`<a>`) element to a button when viewing a run detail. The button now:
   - Calls `onBack()` on regular click (preserving filters like the back button does)
   - Opens `/` in a new tab when Cmd/Ctrl is held (for opening in new tab use case)

2. **Header.test.tsx**: Updated tests to verify:
   - Logo is rendered as a button (not link) when viewing run details
   - Clicking the logo calls `onBack()`
   - Cmd/Ctrl+click opens in new tab

### Why This Fixes the Issue

Previously, clicking the logo navigated directly to `/` which lost all filter state (benchmark, status, text filters). Now clicking the logo behaves exactly like the back button - it simply calls `onBack()` which sets `selectedRun` to null, preserving the current filters in the URL state.

### Testing

All 270 tests pass including the new Header tests.

Closes #108