### PR TITLE
Add eval monitor detail links to exported paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ cd frontend && npm run lint   # run eslint
   - `evaluation_branch` / `eval_branch` → `https://github.com/OpenHands/evaluation/tree/<branch>` (strips `refs/heads/`)
   - `benchmarks_branch` → `https://github.com/OpenHands/benchmarks/tree/<branch>` (strips `refs/heads/`)
 
+## Export Paths Modal Notes
+- `frontend/src/components/ExportPathsModal.tsx` can export both results-bucket file URLs and an `eval_monitor_url` detail-page link for each run.
+- `eval_monitor_url` is built from the current monitor URL, preserves existing query params like date/days/filters, and clears any hash before adding `run=<slug>`.
+
 ## Coding Style
 - TypeScript strict mode, React functional components with hooks
 - Tailwind CSS for styling with custom `oh-*` color theme (defined in `tailwind.config.js`)

--- a/frontend/src/__tests__/ExportPathsModal.test.tsx
+++ b/frontend/src/__tests__/ExportPathsModal.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
-import ExportPathsModal, { EXPORTABLE_FILES, getFilePath, buildFilterString } from '../components/ExportPathsModal'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import ExportPathsModal, { EXPORTABLE_FILES, getFilePath, buildFilterString, getEvalMonitorUrl } from '../components/ExportPathsModal'
 
 describe('ExportPathsModal', () => {
   const mockOnClose = vi.fn()
@@ -9,14 +9,20 @@ describe('ExportPathsModal', () => {
     { slug: 'swebench/model-a/123', jobId: '123' },
     { slug: 'gaia/model-b/456', jobId: '456' },
   ]
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
 
   beforeEach(() => {
     mockOnClose.mockClear()
-    // Mock URL.createObjectURL and URL.revokeObjectURL
-    vi.stubGlobal('URL', {
-      createObjectURL: vi.fn(() => 'blob:test'),
-      revokeObjectURL: vi.fn(),
-    })
+    window.history.replaceState({}, '', '/')
+    URL.createObjectURL = vi.fn(() => 'blob:test')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+    vi.restoreAllMocks()
   })
 
   it('does not render when closed', () => {
@@ -45,7 +51,7 @@ describe('ExportPathsModal', () => {
       />
     )
     expect(screen.getByText('Export current instances paths to JSON')).toBeInTheDocument()
-    expect(screen.getByText(/Select which files to include.*2 runs/)).toBeInTheDocument()
+    expect(screen.getByText(/Select which files or links to include.*2 runs/)).toBeInTheDocument()
   })
 
   it('shows all exportable file checkboxes', () => {
@@ -235,13 +241,50 @@ describe('ExportPathsModal', () => {
       />
     )
 
-    fireEvent.click(screen.getByTestId('copy-button'))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-button'))
+    })
 
     expect(mockWriteText).toHaveBeenCalled()
     const copiedJson = JSON.parse(mockWriteText.mock.calls[0][0])
     expect(copiedJson).toHaveLength(2)
     expect(copiedJson[0].eval_job_id).toBe('123')
     expect(copiedJson[0]['params.json']).toContain('swebench/model-a/123')
+  })
+
+  it('includes eval monitor detail links when selected for export', async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, {
+      clipboard: { writeText: mockWriteText }
+    })
+    window.history.replaceState({}, '', '/?date=2025-01-01&days=2&status=completed#ignore-me')
+
+    render(
+      <ExportPathsModal
+        isOpen={true}
+        onClose={mockOnClose}
+        filteredRuns={mockFilteredRuns}
+        filterBenchmark="all"
+        filterStatus="completed"
+        filterText=""
+      />
+    )
+
+    fireEvent.click(screen.getByTestId('checkbox-eval_monitor_url'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-button'))
+    })
+
+    expect(mockWriteText).toHaveBeenCalled()
+    const copiedJson = JSON.parse(mockWriteText.mock.calls[0][0])
+    const detailUrl = new URL(copiedJson[0].eval_monitor_url)
+
+    expect(detailUrl.searchParams.get('date')).toBe('2025-01-01')
+    expect(detailUrl.searchParams.get('days')).toBe('2')
+    expect(detailUrl.searchParams.get('status')).toBe('completed')
+    expect(detailUrl.searchParams.get('run')).toBe('swebench/model-a/123')
+    expect(detailUrl.hash).toBe('')
   })
 
   it('shows Copied! text after clicking copy button', async () => {
@@ -264,9 +307,10 @@ describe('ExportPathsModal', () => {
     const copyButton = screen.getByTestId('copy-button')
     expect(copyButton).toHaveTextContent('Copy')
 
-    fireEvent.click(copyButton)
+    await act(async () => {
+      fireEvent.click(copyButton)
+    })
 
-    // Wait for state update
     await vi.waitFor(() => {
       expect(screen.getByTestId('copy-button')).toHaveTextContent('Copied!')
     })
@@ -377,11 +421,19 @@ describe('EXPORTABLE_FILES', () => {
     expect(filenames).toContain('params.json')
     expect(filenames).toContain('results.tar.gz')
     expect(filenames).toContain('output.report.json')
+    expect(filenames).toContain('eval_monitor_url')
     expect(filenames).toContain('init.json')
     expect(filenames).toContain('error.json')
     expect(filenames).toContain('cost_report_v2.jsonl')
     expect(filenames).toContain('cost_report.jsonl')
     expect(filenames).toContain('conversation-error-report.txt')
+  })
+})
+
+describe('getEvalMonitorUrl', () => {
+  it('preserves current filters and clears hashes while selecting the run', () => {
+    expect(getEvalMonitorUrl('https://eval.example.com/?date=2025-01-01&days=2#section', 'swebench/model/123'))
+      .toBe('https://eval.example.com/?date=2025-01-01&days=2&run=swebench%2Fmodel%2F123')
   })
 })
 

--- a/frontend/src/components/ExportPathsModal.tsx
+++ b/frontend/src/components/ExportPathsModal.tsx
@@ -5,12 +5,14 @@ export interface ExportableFile {
   filename: string
   subdir?: string // e.g., 'metadata' for params.json
   defaultChecked: boolean
+  type?: 'results-file' | 'detail-page'
 }
 
 export const EXPORTABLE_FILES: ExportableFile[] = [
   { filename: 'params.json', subdir: 'metadata', defaultChecked: true },
   { filename: 'results.tar.gz', defaultChecked: true },
   { filename: 'output.report.json', defaultChecked: true },
+  { filename: 'eval_monitor_url', defaultChecked: false, type: 'detail-page' },
   { filename: 'init.json', subdir: 'metadata', defaultChecked: false },
   { filename: 'error.json', subdir: 'metadata', defaultChecked: false },
   { filename: 'run-infer-start.json', subdir: 'metadata', defaultChecked: false },
@@ -59,6 +61,13 @@ export function buildFilterString(filterBenchmark: string, filterStatus: string,
 
 export function getFilePath(file: ExportableFile): string {
   return file.subdir ? `${file.subdir}/${file.filename}` : file.filename
+}
+
+export function getEvalMonitorUrl(currentUrl: string, slug: string): string {
+  const url = new URL(currentUrl)
+  url.searchParams.set('run', slug)
+  url.hash = ''
+  return url.toString()
 }
 
 export default function ExportPathsModal({ isOpen, onClose, filteredRuns, filterBenchmark, filterStatus, filterText }: ExportPathsModalProps) {
@@ -112,10 +121,15 @@ export default function ExportPathsModal({ isOpen, onClose, filteredRuns, filter
     return filteredRuns.map(run => {
       const entry: Record<string, string> = { eval_job_id: run.jobId }
       EXPORTABLE_FILES.forEach(file => {
-        if (selectedFiles.has(file.filename)) {
-          const path = getFilePath(file)
-          entry[file.filename] = getResultsUrl(run.slug, path)
+        if (!selectedFiles.has(file.filename)) return
+
+        if (file.type === 'detail-page') {
+          entry[file.filename] = getEvalMonitorUrl(window.location.href, run.slug)
+          return
         }
+
+        const path = getFilePath(file)
+        entry[file.filename] = getResultsUrl(run.slug, path)
       })
       return entry
     })
@@ -173,7 +187,7 @@ export default function ExportPathsModal({ isOpen, onClose, filteredRuns, filter
         </div>
 
         <p className="text-sm text-oh-text-muted mb-4">
-          Select which files to include in the export ({filteredRuns.length} run{filteredRuns.length !== 1 ? 's' : ''})
+          Select which files or links to include in the export ({filteredRuns.length} run{filteredRuns.length !== 1 ? 's' : ''})
         </p>
 
         <div className="flex items-center gap-2 mb-3 pb-3 border-b border-oh-border">


### PR DESCRIPTION
## Summary
- add an `eval_monitor_url` export option in the export paths modal
- generate eval monitor detail links from the current monitor URL while preserving existing date/day/filter query params
- cover the new export option and URL helper with tests

## Testing
- `make test`
- `make typecheck`

Closes #112.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/406e179a-dbfc-4e6e-9eb0-641e362cb799)