### PR TITLE
Add cache bust parameter to run-infer-progress.txt fetch

### DIFF
--- a/frontend/src/__tests__/InferProgressGraph.test.tsx
+++ b/frontend/src/__tests__/InferProgressGraph.test.tsx
@@ -156,4 +156,24 @@ describe('InferProgressGraph', () => {
     const paths = chartSvg?.querySelectorAll('path[stroke]')
     expect(paths?.length).toBeGreaterThanOrEqual(4)
   })
+
+  it('includes cache bust parameter in fetch URL', async () => {
+    const mockData = `2026-03-26 21:30:20 UTC, 0, 0, 0, 0`
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => mockData,
+    })
+    globalThis.fetch = mockFetch
+
+    render(<InferProgressGraph slug={defaultSlug} />)
+    
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled()
+    })
+
+    const fetchUrl = mockFetch.mock.calls[0][0]
+    expect(fetchUrl).toMatch(/\/api\/swebench\/litellm_proxy-claude-sonnet\/123\/metadata\/run-infer-progress\.txt\?\d+/)
+    expect(fetchUrl).toContain('/metadata/run-infer-progress.txt?')
+  })
 })

--- a/frontend/src/components/InferProgressGraph.tsx
+++ b/frontend/src/components/InferProgressGraph.tsx
@@ -25,7 +25,8 @@ export default function InferProgressGraph({ slug }: InferProgressGraphProps) {
     const fetchData = async () => {
       try {
         const cleanSlug = slug.replace(/\/$/, '')
-        const url = `/api/${cleanSlug}/metadata/run-infer-progress.txt`
+        const cacheBust = Math.floor(Date.now() / 1000)
+        const url = `/api/${cleanSlug}/metadata/run-infer-progress.txt?${cacheBust}`
         const res = await fetch(url)
         if (cancelled) return
         if (!res.ok) {


### PR DESCRIPTION
## Description
This PR adds the cache bust parameter to the fetch request for `run-infer-progress.txt`, using the same technique already employed for fetching `YYYY-MM-DD.txt` files in `api.ts`.

## Changes
- Added `cacheBust = Math.floor(Date.now() / 1000)` to the `InferProgressGraph` component
- Updated the fetch URL to include the cache bust query parameter: `?${cacheBust}`
- Added a test to verify the cache bust parameter is included in the fetch URL

## Testing
- All existing tests continue to pass (284 tests)
- Added new test case `includes cache bust parameter in fetch URL` to verify the fix

## Related Issue
Fixes #116

---
_This PR was created by an AI assistant (OpenHands) on behalf of the repository maintainers._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/27a71e3e-62fb-4ba9-ae92-a135a6ecaaf1)