### PR TITLE
feat: show active runs count and per-author breakdown in detail page

### DIFF
--- a/frontend/src/__tests__/RunListView.test.tsx
+++ b/frontend/src/__tests__/RunListView.test.tsx
@@ -281,4 +281,166 @@ describe('RunListView', () => {
       expect(screen.getByRole('option', { name: 'Active' })).toBeInTheDocument()
     })
   })
+
+  describe('active runs summary', () => {
+    const createMetadata = (status: string, triggeredBy: string = 'user1') => {
+      const base = {
+        init: null,
+        params: triggeredBy ? { triggered_by: triggeredBy } : null,
+        error: null,
+        runInferStart: null,
+        runInferEnd: null,
+        evalInferStart: null,
+        evalInferEnd: null,
+        cancelEval: null
+      }
+      switch (status) {
+        case 'pending':
+          return { ...base }
+        case 'building':
+          return { ...base, params: { ...base.params, timestamp: '2025-01-01T00:00:00Z' } }
+        case 'running-infer':
+          return { ...base, runInferStart: { timestamp: '2025-01-01T00:00:00Z' } }
+        case 'running-eval':
+          return { ...base, evalInferStart: { timestamp: '2025-01-01T00:00:00Z' } }
+        case 'completed':
+          return { ...base, evalInferEnd: { timestamp: '2025-01-01T00:00:00Z' } }
+        default:
+          return base
+      }
+    }
+
+    it('shows total active runs count', () => {
+      const props = {
+        runs: [
+          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' },
+          { slug: 'swebench/run2/2', benchmark: 'swebench', model: 'run2', jobId: '2' },
+          { slug: 'swebench/run3/3', benchmark: 'swebench', model: 'run3', jobId: '3' }
+        ],
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap: {
+          'swebench/run1/1': createMetadata('running-infer', 'user1'),
+          'swebench/run2/2': createMetadata('building', 'user1'),
+          'swebench/run3/3': createMetadata('completed', 'user1')
+        },
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: ['swebench/run1/1', 'swebench/run2/2', 'swebench/run3/3'] }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn()
+      }
+      render(<RunListView {...props} />)
+      expect(screen.getByTestId('total-active-runs').textContent).toBe('2')
+    })
+
+    it('shows per-author breakdown for active runs', () => {
+      const props = {
+        runs: [
+          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' },
+          { slug: 'swebench/run2/2', benchmark: 'swebench', model: 'run2', jobId: '2' },
+          { slug: 'swebench/run3/3', benchmark: 'swebench', model: 'run3', jobId: '3' }
+        ],
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap: {
+          'swebench/run1/1': createMetadata('running-infer', 'alice'),
+          'swebench/run2/2': createMetadata('building', 'alice'),
+          'swebench/run3/3': createMetadata('running-infer', 'bob')
+        },
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: ['swebench/run1/1', 'swebench/run2/2', 'swebench/run3/3'] }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn()
+      }
+      render(<RunListView {...props} />)
+      expect(screen.getByTestId('active-runs-author-alice').textContent).toContain('alice: 2')
+      expect(screen.getByTestId('active-runs-author-bob').textContent).toContain('bob: 1')
+    })
+
+    it('shows error color when total active >= 12', () => {
+      const runs = Array.from({ length: 12 }, (_, i) => ({
+        slug: `swebench/run${i}/${i}`,
+        benchmark: 'swebench',
+        model: `run${i}`,
+        jobId: String(i)
+      }))
+      const runMetadataMap: Record<string, ReturnType<typeof createMetadata>> = {}
+      runs.forEach((run) => {
+        runMetadataMap[run.slug] = createMetadata('running-infer', 'user1')
+      })
+      const props = {
+        runs,
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap,
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: runs.map(r => r.slug) }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn()
+      }
+      render(<RunListView {...props} />)
+      expect(screen.getByTestId('total-active-runs').className).toContain('text-oh-error')
+    })
+
+    it('shows primary color when total active < 12', () => {
+      const props = {
+        runs: [
+          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' }
+        ],
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap: {
+          'swebench/run1/1': createMetadata('running-infer', 'user1')
+        },
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: ['swebench/run1/1'] }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn()
+      }
+      render(<RunListView {...props} />)
+      expect(screen.getByTestId('total-active-runs').className).toContain('text-oh-primary')
+    })
+
+    it('does not show active summary when loading metadata', () => {
+      const props = {
+        runs: [
+          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' }
+        ],
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap: {},
+        loadingMetadataList: true,
+        dayGroups: [{ date: '2025-01-01', runs: ['swebench/run1/1'] }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn()
+      }
+      render(<RunListView {...props} />)
+      expect(screen.queryByTestId('total-active-runs')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -202,6 +202,23 @@ export default function RunListView({
     return counts
   }, [runsWithStatus])
 
+  // Active runs count and per-author breakdown (from all runs, independent of filters)
+  const { totalActive, activeByAuthor } = useMemo(() => {
+    let totalActive = 0
+    const activeByAuthor: Record<string, number> = {}
+    const activeStatuses: StatusType[] = ['pending', 'building', 'running-infer', 'running-eval']
+    runsWithStatus.forEach(r => {
+      if (activeStatuses.includes(r.status)) {
+        totalActive++
+        const author = r.triggeredBy
+        if (author && author !== '—') {
+          activeByAuthor[author] = (activeByAuthor[author] || 0) + 1
+        }
+      }
+    })
+    return { totalActive, activeByAuthor }
+  }, [runsWithStatus])
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -255,17 +272,31 @@ export default function RunListView({
             </span>
           )}
         </h2>
-        <div className="flex items-center gap-3 flex-wrap">
-          {Object.entries(statusCounts).map(([status, count]) => (
-            <button
-              key={status}
-              onClick={() => setFilterStatus(filterStatus === status ? 'all' : status)}
-              className={`text-xs px-2 py-1 rounded transition-colors ${filterStatus === status ? 'ring-1 ring-oh-primary' : 'opacity-70 hover:opacity-100'}`}
-            >
-              <StatusBadge status={status as StatusType} />
-              <span className="ml-1 text-oh-text-muted">{count}</span>
-            </button>
-          ))}
+        <div className="flex items-center gap-4 flex-wrap">
+          <div className="flex items-center gap-3 flex-wrap">
+            {Object.entries(statusCounts).map(([status, count]) => (
+              <button
+                key={status}
+                onClick={() => setFilterStatus(filterStatus === status ? 'all' : status)}
+                className={`text-xs px-2 py-1 rounded transition-colors ${filterStatus === status ? 'ring-1 ring-oh-primary' : 'opacity-70 hover:opacity-100'}`}
+              >
+                <StatusBadge status={status as StatusType} />
+                <span className="ml-1 text-oh-text-muted">{count}</span>
+              </button>
+            ))}
+          </div>
+          {!loadingMetadataList && totalActive > 0 && (
+            <div className="flex items-center gap-3 flex-wrap text-xs">
+              <span className="text-oh-text-muted">
+                Active: <span data-testid="total-active-runs" className={`font-bold ${totalActive >= 12 ? 'text-oh-error' : 'text-oh-primary'}`}>{totalActive}</span>
+              </span>
+              {Object.entries(activeByAuthor).sort((a, b) => b[1] - a[1]).map(([author, count]) => (
+                <span key={author} data-testid={`active-runs-author-${author}`} className="text-oh-text-muted">
+                  <span className="font-medium text-oh-text">{author}</span>: {count}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

This PR implements the feature requested in issue #124 by adding an active runs summary section to the list page that displays:

- **Total count of active runs** - counts all runs with status: pending, building, running-infer, running-eval
- **Per-author breakdown** - shows how many active runs each author (triggered_by) has, sorted by count
- **Visual warning** - displays in red when total >= 12 runs to alert users of potential errors

The summary is computed from all runs (independent of filters) and updates after all metadata is loaded.

## Changes

### frontend/src/components/RunListView.tsx
- Added `useMemo` hook to compute active runs count and per-author breakdown from all runs (not filtered)
- Added UI to display the active runs summary in the summary bar
- Shows error styling (red) when totalActive >= 12

### frontend/src/__tests__/RunListView.test.tsx
- Added tests for the new active runs summary feature

## Testing

All 290 tests pass. Type checking passes.

Closes #124