### PR TITLE
Fix #126: Count active inference workers instead of runs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -250,6 +250,7 @@ export default function App() {
             setFilterStatus={setFilterStatus}
             filterText={filterText}
             setFilterText={setFilterText}
+            showDetail={!!selectedRun}
           />
         )}
       </main>

--- a/frontend/src/__tests__/RunListView.test.tsx
+++ b/frontend/src/__tests__/RunListView.test.tsx
@@ -70,6 +70,16 @@ describe('RunListView', () => {
     filterText: '',
     setFilterText: vi.fn()
   }
+
+  beforeEach(() => {
+    mockOnSelectRun.mockClear()
+    vi.stubGlobal('window', {
+      ...window,
+      location: { href: 'http://localhost/' },
+      open: vi.fn()
+    })
+  })
+
   const defaultProps = {
     runs: [
       {
@@ -90,17 +100,9 @@ describe('RunListView', () => {
     filterStatus: 'all',
     setFilterStatus: vi.fn(),
     filterText: '',
-    setFilterText: vi.fn()
+    setFilterText: vi.fn(),
+    showDetail: false
   }
-
-  beforeEach(() => {
-    mockOnSelectRun.mockClear()
-    vi.stubGlobal('window', {
-      ...window,
-      location: { href: 'http://localhost/' },
-      open: vi.fn()
-    })
-  })
 
   it('calls onSelectRun on normal click', () => {
     render(<RunListView {...defaultProps} />)
@@ -282,11 +284,11 @@ describe('RunListView', () => {
     })
   })
 
-  describe('active runs summary', () => {
-    const createMetadata = (status: string, triggeredBy: string = 'user1') => {
+  describe('active workers summary', () => {
+    const createMetadata = (status: string, triggeredBy: string = 'user1', extraParams: Record<string, unknown> = {}) => {
       const base = {
         init: null,
-        params: triggeredBy ? { triggered_by: triggeredBy } : null,
+        params: triggeredBy ? { triggered_by: triggeredBy, ...extraParams } : null,
         error: null,
         runInferStart: null,
         runInferEnd: null,
@@ -298,7 +300,7 @@ describe('RunListView', () => {
         case 'pending':
           return { ...base }
         case 'building':
-          return { ...base, params: { ...base.params, timestamp: '2025-01-01T00:00:00Z' } }
+          return { ...base, params: base.params ? { ...base.params, timestamp: '2025-01-01T00:00:00Z' } : { timestamp: '2025-01-01T00:00:00Z' } }
         case 'running-infer':
           return { ...base, runInferStart: { timestamp: '2025-01-01T00:00:00Z' } }
         case 'running-eval':
@@ -310,7 +312,7 @@ describe('RunListView', () => {
       }
     }
 
-    it('shows total active runs count', () => {
+    it('shows total active workers count', () => {
       const props = {
         runs: [
           { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' },
@@ -332,13 +334,15 @@ describe('RunListView', () => {
         filterStatus: 'all',
         setFilterStatus: vi.fn(),
         filterText: '',
-        setFilterText: vi.fn()
+        setFilterText: vi.fn(),
+        showDetail: false
       }
       render(<RunListView {...props} />)
-      expect(screen.getByTestId('total-active-runs').textContent).toBe('2')
+      // 2 active runs with default 20 workers each = 40 workers
+      expect(screen.getByTestId('total-active-workers').textContent).toBe('40')
     })
 
-    it('shows per-author breakdown for active runs', () => {
+    it('shows per-author breakdown for active workers based on worker count', () => {
       const props = {
         runs: [
           { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' },
@@ -349,9 +353,9 @@ describe('RunListView', () => {
         error: null,
         onSelectRun: mockOnSelectRun,
         runMetadataMap: {
-          'swebench/run1/1': createMetadata('running-infer', 'alice'),
-          'swebench/run2/2': createMetadata('building', 'alice'),
-          'swebench/run3/3': createMetadata('running-infer', 'bob')
+          'swebench/run1/1': createMetadata('running-infer', 'alice', { num_infer_workers: 10 }),
+          'swebench/run2/2': createMetadata('building', 'alice', { num_infer_workers: 5 }),
+          'swebench/run3/3': createMetadata('running-infer', 'bob', { num_infer_workers: 2 })
         },
         loadingMetadataList: false,
         dayGroups: [{ date: '2025-01-01', runs: ['swebench/run1/1', 'swebench/run2/2', 'swebench/run3/3'] }],
@@ -360,44 +364,44 @@ describe('RunListView', () => {
         filterStatus: 'all',
         setFilterStatus: vi.fn(),
         filterText: '',
-        setFilterText: vi.fn()
+        setFilterText: vi.fn(),
+        showDetail: false
       }
       render(<RunListView {...props} />)
-      expect(screen.getByTestId('active-runs-author-alice').textContent).toContain('alice: 2')
-      expect(screen.getByTestId('active-runs-author-bob').textContent).toContain('bob: 1')
+      expect(screen.getByTestId('total-active-workers').textContent).toBe('17')
+      expect(screen.getByTestId('active-workers-author-alice').textContent).toContain('alice: 15')
+      expect(screen.getByTestId('active-workers-author-bob').textContent).toContain('bob: 2')
     })
 
-    it('shows error color when total active >= 12', () => {
-      const runs = Array.from({ length: 12 }, (_, i) => ({
-        slug: `swebench/run${i}/${i}`,
-        benchmark: 'swebench',
-        model: `run${i}`,
-        jobId: String(i)
-      }))
-      const runMetadataMap: Record<string, ReturnType<typeof createMetadata>> = {}
-      runs.forEach((run) => {
-        runMetadataMap[run.slug] = createMetadata('running-infer', 'user1')
-      })
+    it('calculates workers from eval_limit when num_infer_workers not set', () => {
       const props = {
-        runs,
+        runs: [
+          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' },
+          { slug: 'swebench/run2/2', benchmark: 'swebench', model: 'run2', jobId: '2' }
+        ],
         loading: false,
         error: null,
         onSelectRun: mockOnSelectRun,
-        runMetadataMap,
+        runMetadataMap: {
+          'swebench/run1/1': createMetadata('running-infer', 'user1', { eval_limit: 50 }),
+          'swebench/run2/2': createMetadata('running-infer', 'user1', { eval_limit: 10 })
+        },
         loadingMetadataList: false,
-        dayGroups: [{ date: '2025-01-01', runs: runs.map(r => r.slug) }],
+        dayGroups: [{ date: '2025-01-01', runs: ['swebench/run1/1', 'swebench/run2/2'] }],
         filterBenchmark: 'all',
         setFilterBenchmark: vi.fn(),
         filterStatus: 'all',
         setFilterStatus: vi.fn(),
         filterText: '',
-        setFilterText: vi.fn()
+        setFilterText: vi.fn(),
+        showDetail: false
       }
       render(<RunListView {...props} />)
-      expect(screen.getByTestId('total-active-runs').className).toContain('text-oh-error')
+      // eval_limit: 50 -> 50 (no cap), eval_limit: 10 -> 10
+      expect(screen.getByTestId('total-active-workers').textContent).toBe('60')
     })
 
-    it('shows primary color when total active < 12', () => {
+    it('shows primary color when total active workers < 240', () => {
       const props = {
         runs: [
           { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' }
@@ -415,10 +419,102 @@ describe('RunListView', () => {
         filterStatus: 'all',
         setFilterStatus: vi.fn(),
         filterText: '',
-        setFilterText: vi.fn()
+        setFilterText: vi.fn(),
+        showDetail: false
       }
       render(<RunListView {...props} />)
-      expect(screen.getByTestId('total-active-runs').className).toContain('text-oh-primary')
+      expect(screen.getByTestId('total-active-workers').className).toContain('text-oh-primary')
+    })
+
+    it('shows orange color when total active workers >= 240 and <= 256', () => {
+      const runs = Array.from({ length: 12 }, (_, i) => ({
+        slug: `swebench/run${i}/${i}`,
+        benchmark: 'swebench',
+        model: `run${i}`,
+        jobId: String(i)
+      }))
+      const runMetadataMap: Record<string, ReturnType<typeof createMetadata>> = {}
+      runs.forEach((run) => {
+        // 12 runs * 20 workers each = 240 workers (orange threshold)
+        runMetadataMap[run.slug] = createMetadata('running-infer', 'user1', { num_infer_workers: 20 })
+      })
+      const props = {
+        runs,
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap,
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: runs.map(r => r.slug) }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn(),
+        showDetail: false
+      }
+      render(<RunListView {...props} />)
+      expect(screen.getByTestId('total-active-workers').textContent).toBe('240')
+      expect(screen.getByTestId('total-active-workers').className).toContain('text-orange-400')
+    })
+
+    it('shows error color when total active workers > 256', () => {
+      const runs = Array.from({ length: 13 }, (_, i) => ({
+        slug: `swebench/run${i}/${i}`,
+        benchmark: 'swebench',
+        model: `run${i}`,
+        jobId: String(i)
+      }))
+      const runMetadataMap: Record<string, ReturnType<typeof createMetadata>> = {}
+      runs.forEach((run) => {
+        // 13 runs * 20 workers each = 260 workers (red threshold)
+        runMetadataMap[run.slug] = createMetadata('running-infer', 'user1', { num_infer_workers: 20 })
+      })
+      const props = {
+        runs,
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap,
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: runs.map(r => r.slug) }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn(),
+        showDetail: false
+      }
+      render(<RunListView {...props} />)
+      expect(screen.getByTestId('total-active-workers').textContent).toBe('260')
+      expect(screen.getByTestId('total-active-workers').className).toContain('text-oh-error')
+    })
+
+    it('hides active workers summary when showDetail is true', () => {
+      const props = {
+        runs: [
+          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' }
+        ],
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap: {
+          'swebench/run1/1': createMetadata('running-infer', 'user1')
+        },
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: ['swebench/run1/1'] }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn(),
+        showDetail: true
+      }
+      render(<RunListView {...props} />)
+      expect(screen.queryByTestId('total-active-workers')).not.toBeInTheDocument()
     })
 
     it('does not show active summary when loading metadata', () => {

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport } from '../api'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, getActiveWorkersForInstance } from '../api'
 import type { RunMetadata } from '../api'
 
 const originalFetch = globalThis.fetch
@@ -446,6 +446,72 @@ describe('fetchCostReport', () => {
     await fetchCostReport('swebench/model/123/')
     const calledUrls = (fetchMock as ReturnType<typeof vi.fn>).mock.calls.map((call: unknown[]) => String(call[0]))
     expect(calledUrls.every(u => !u.includes('//'))).toBe(true)
+  })
+})
+
+describe('getActiveWorkersForInstance', () => {
+  it('returns min(num_infer_workers, eval_limit) when both are set', () => {
+    const metadata = makeMetadata({
+      params: { num_infer_workers: 30, eval_limit: 100 },
+    })
+    expect(getActiveWorkersForInstance(metadata)).toBe(30)
+  })
+
+  it('returns num_infer_workers when eval_limit is not set', () => {
+    const metadata = makeMetadata({
+      params: { num_infer_workers: 50 },
+    })
+    expect(getActiveWorkersForInstance(metadata)).toBe(50)
+  })
+
+  it('returns eval_limit when num_infer_workers is not set', () => {
+    const metadata = makeMetadata({
+      params: { eval_limit: 15 },
+    })
+    expect(getActiveWorkersForInstance(metadata)).toBe(15)
+  })
+
+  it('returns 20 when neither num_infer_workers nor eval_limit is set', () => {
+    const metadata = makeMetadata()
+    expect(getActiveWorkersForInstance(metadata)).toBe(20)
+  })
+
+  it('returns 20 when params is null', () => {
+    const metadata = makeMetadata({ params: null })
+    expect(getActiveWorkersForInstance(metadata)).toBe(20)
+  })
+
+  it('returns 20 when params is empty object', () => {
+    const metadata = makeMetadata({ params: {} })
+    expect(getActiveWorkersForInstance(metadata)).toBe(20)
+  })
+
+  it('ignores non-numeric num_infer_workers and uses eval_limit', () => {
+    const metadata = makeMetadata({
+      params: { num_infer_workers: 'string' as unknown as number, eval_limit: 10 },
+    })
+    expect(getActiveWorkersForInstance(metadata)).toBe(10)
+  })
+
+  it('ignores null num_infer_workers and uses eval_limit', () => {
+    const metadata = makeMetadata({
+      params: { num_infer_workers: null, eval_limit: 5 },
+    })
+    expect(getActiveWorkersForInstance(metadata)).toBe(5)
+  })
+
+  it('ignores null eval_limit and uses num_infer_workers', () => {
+    const metadata = makeMetadata({
+      params: { num_infer_workers: 30, eval_limit: null },
+    })
+    expect(getActiveWorkersForInstance(metadata)).toBe(30)
+  })
+
+  it('returns min when both are set and num_infer_workers < eval_limit', () => {
+    const metadata = makeMetadata({
+      params: { num_infer_workers: 10, eval_limit: 50 },
+    })
+    expect(getActiveWorkersForInstance(metadata)).toBe(10)
   })
 })
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -328,3 +328,30 @@ export async function fetchSubmissionData(slug: string): Promise<SubmissionData 
     url: data.url,
   }
 }
+
+/** Calculate active workers for a single instance based on its metadata.
+ *  active_workers = if num_infer_workers != null and eval_limit != null then min(num_infer_workers, eval_limit)
+ *                   else if num_infer_workers != null then num_infer_workers
+ *                   else if eval_limit != null then eval_limit
+ *                   else 20
+ */
+export function getActiveWorkersForInstance(metadata: RunMetadata): number {
+  const params = metadata.params
+  if (params) {
+    const numInferWorkers = params.num_infer_workers
+    const evalLimit = params.eval_limit
+    const hasNumInferWorkers = typeof numInferWorkers === 'number' && numInferWorkers !== null
+    const hasEvalLimit = typeof evalLimit === 'number' && evalLimit !== null
+    
+    if (hasNumInferWorkers && hasEvalLimit) {
+      return Math.min(numInferWorkers as number, evalLimit as number)
+    }
+    if (hasNumInferWorkers) {
+      return numInferWorkers as number
+    }
+    if (hasEvalLimit) {
+      return evalLimit as number
+    }
+  }
+  return 20
+}

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import type { RunMetadata, DayRunGroup } from '../api'
-import { getStageStatus, getRuntime, isFinished, extractTriggeredBy, extractTriggerReason } from '../api'
+import { getStageStatus, getRuntime, isFinished, extractTriggeredBy, extractTriggerReason, getActiveWorkersForInstance } from '../api'
 import ExportPathsModal from './ExportPathsModal'
 
 interface RunInfo {
@@ -24,6 +24,7 @@ interface RunListViewProps {
   setFilterStatus: (value: string) => void
   filterText: string
   setFilterText: (value: string) => void
+  showDetail: boolean
 }
 
 type StatusType = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
@@ -113,7 +114,8 @@ export default function RunListView({
   filterStatus,
   setFilterStatus,
   filterText,
-  setFilterText
+  setFilterText,
+  showDetail
 }: RunListViewProps) {
   const showMultipleDays = dayGroups.length > 1
   const [isExportModalOpen, setIsExportModalOpen] = useState(false)
@@ -202,22 +204,25 @@ export default function RunListView({
     return counts
   }, [runsWithStatus])
 
-  // Active runs count and per-author breakdown (from all runs, independent of filters)
-  const { totalActive, activeByAuthor } = useMemo(() => {
-    let totalActive = 0
-    const activeByAuthor: Record<string, number> = {}
+  // Active workers count and per-author breakdown (from all runs, independent of filters)
+  // active_workers = num_infer_workers if set, else min(eval_limit || 20, 20)
+  const { totalActiveWorkers, activeWorkersByAuthor } = useMemo(() => {
+    let totalActiveWorkers = 0
+    const activeWorkersByAuthor: Record<string, number> = {}
     const activeStatuses: StatusType[] = ['pending', 'building', 'running-infer', 'running-eval']
     runsWithStatus.forEach(r => {
       if (activeStatuses.includes(r.status)) {
-        totalActive++
+        const metadata = runMetadataMap[r.slug]
+        const workers = metadata ? getActiveWorkersForInstance(metadata) : 1
+        totalActiveWorkers += workers
         const author = r.triggeredBy
         if (author && author !== '—') {
-          activeByAuthor[author] = (activeByAuthor[author] || 0) + 1
+          activeWorkersByAuthor[author] = (activeWorkersByAuthor[author] || 0) + workers
         }
       }
     })
-    return { totalActive, activeByAuthor }
-  }, [runsWithStatus])
+    return { totalActiveWorkers, activeWorkersByAuthor }
+  }, [runsWithStatus, runMetadataMap])
 
   if (loading) {
     return (
@@ -285,13 +290,13 @@ export default function RunListView({
               </button>
             ))}
           </div>
-          {!loadingMetadataList && totalActive > 0 && (
+          {!loadingMetadataList && !showDetail && totalActiveWorkers > 0 && (
             <div className="flex items-center gap-3 flex-wrap text-xs">
               <span className="text-oh-text-muted">
-                Active: <span data-testid="total-active-runs" className={`font-bold ${totalActive >= 12 ? 'text-oh-error' : 'text-oh-primary'}`}>{totalActive}</span>
+                Active Workers: <span data-testid="total-active-workers" className={`font-bold ${totalActiveWorkers > 256 ? 'text-oh-error' : totalActiveWorkers >= 240 ? 'text-orange-400' : 'text-oh-primary'}`}>{totalActiveWorkers}</span>
               </span>
-              {Object.entries(activeByAuthor).sort((a, b) => b[1] - a[1]).map(([author, count]) => (
-                <span key={author} data-testid={`active-runs-author-${author}`} className="text-oh-text-muted">
+              {Object.entries(activeWorkersByAuthor).sort((a, b) => b[1] - a[1]).map(([author, count]) => (
+                <span key={author} data-testid={`active-workers-author-${author}`} className="text-oh-text-muted">
                   <span className="font-medium text-oh-text">{author}</span>: {count}
                 </span>
               ))}


### PR DESCRIPTION
## Summary

This PR fixes issue #126 by changing how active instances are counted:

### Changes

1. **New `getActiveWorkersForInstance` function** (`frontend/src/api.ts`):
   - Calculates active workers per instance based on `num_infer_workers` and `eval_limit` metadata fields
   - Formula:
     - If both `num_infer_workers` and `eval_limit` are set: `min(num_infer_workers, eval_limit)`
     - If only `num_infer_workers` is set: `num_infer_workers`
     - If only `eval_limit` is set: `eval_limit`
     - If neither is set: `20` (default)

2. **Updated `RunListView`** (`frontend/src/components/RunListView.tsx`):
   - Shows total active workers instead of active run count
   - Per-author breakdown now shows total workers per author
   - Updated color thresholds:
     - Primary (blue) for workers < 240
     - Orange for workers in range 240-256
     - Red (error) for workers > 256

3. **Loading behavior** (`frontend/src/App.tsx`):
   - Added `showDetail` prop to hide active workers section when viewing run details
   - Active workers section only shows when not viewing detail AND when metadata list is fully loaded

### Tests

Added comprehensive tests for:
- `getActiveWorkersForInstance` function with various parameter combinations
- Active workers calculation in `RunListView`
- Color thresholds (primary, orange, red)
- `showDetail` prop behavior

Closes #126