### PR TITLE
Fix inference speed calculation to use current time and show '-' when complete

### DIFF
--- a/frontend/src/__tests__/InferProgressGraph.test.tsx
+++ b/frontend/src/__tests__/InferProgressGraph.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
-import { describe, it, expect, afterEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import InferProgressGraph from '../components/InferProgressGraph'
 
 const originalFetch = globalThis.fetch
@@ -8,6 +8,7 @@ const originalFetch = globalThis.fetch
 afterEach(() => {
   globalThis.fetch = originalFetch
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 describe('InferProgressGraph', () => {
@@ -63,6 +64,12 @@ describe('InferProgressGraph', () => {
   })
 
   it('renders speed statistics', async () => {
+    vi.useFakeTimers()
+    
+    // Set time to just after the last data point so inference appears running
+    const fixedNow = new Date('2026-03-26T21:33:25Z')
+    vi.setSystemTime(fixedNow)
+    
     const mockData = `2026-03-26 21:30:20 UTC, 0, 0, 0, 0
 2026-03-26 21:31:20 UTC, 0, 2, 0, 0
 2026-03-26 21:32:20 UTC, 2, 3, 1, 0
@@ -75,13 +82,17 @@ describe('InferProgressGraph', () => {
 
     render(<InferProgressGraph slug={defaultSlug} />)
     
-    await waitFor(() => {
-      expect(screen.getByText('Average Speed:')).toBeInTheDocument()
+    // Advance timers to allow the async fetch to complete
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
     })
 
+    expect(screen.getByText('Average Speed:')).toBeInTheDocument()
     expect(screen.getByText('Current Speed:')).toBeInTheDocument()
     const speedTexts = screen.getAllByText(/instances\/min/)
     expect(speedTexts.length).toBe(2)
+    
+    vi.useRealTimers()
   })
 
   it('has section menu with download link', async () => {
@@ -203,5 +214,63 @@ describe('InferProgressGraph', () => {
       expect(colors).toContain('#fb923c') // yellowish orange for critic2
       expect(colors).toContain('#ef4444') // red for critic3
     })
+  })
+
+  it('shows Current Speed as "-" when inference is complete (data older than 1 minute)', async () => {
+    // Data from 2026-03-26 21:33:20 UTC
+    // Since current time is likely more than 1 minute after this, inference should be considered complete
+    const mockData = `2026-03-26 21:33:20 UTC, 0, 0, 0, 0
+2026-03-26 21:33:20 UTC, 3, 5, 2, 1`
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => mockData,
+    })
+
+    render(<InferProgressGraph slug={defaultSlug} />)
+    
+    await waitFor(() => {
+      expect(screen.getByText('Average Speed:')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Current Speed:')).toBeInTheDocument()
+    // Current Speed should show "-" since inference is complete
+    // The "-" is in a sibling span element
+    const dashElement = screen.getByText('-')
+    expect(dashElement).toBeInTheDocument()
+  })
+
+  it('calculates speeds using current time when inference is running', async () => {
+    vi.useFakeTimers()
+    
+    // Set time to just after the last data point so inference appears running
+    const fixedNow = new Date('2026-03-26T21:33:25Z')
+    vi.setSystemTime(fixedNow)
+    
+    // Data from 2026-03-26 21:33:20 UTC - within 1 minute from our fixed time
+    const mockData = `2026-03-26 21:30:20 UTC, 0, 0, 0, 0
+2026-03-26 21:33:20 UTC, 3, 5, 2, 1`
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => mockData,
+    })
+
+    render(<InferProgressGraph slug={defaultSlug} />)
+    
+    // Advance timers to allow the async fetch to complete
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(screen.getByText('Average Speed:')).toBeInTheDocument()
+    expect(screen.getByText('Current Speed:')).toBeInTheDocument()
+    
+    // Both speeds should show numeric values when inference appears running
+    const speedTexts = screen.getAllByText(/instances\/min/)
+    // Should have 2 speed texts: Average Speed and Current Speed
+    expect(speedTexts.length).toBe(2)
+    
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/components/InferProgressGraph.tsx
+++ b/frontend/src/components/InferProgressGraph.tsx
@@ -293,20 +293,32 @@ function SpeedStats({ data }: SpeedStatsProps) {
   const firstPoint = data[0]
   const lastPoint = data[data.length - 1]
   
-  const totalTime = (lastPoint.timestamp.getTime() - firstPoint.timestamp.getTime()) / 1000 / 60
+  // Use current UTC time for calculations during inference
+  const now = new Date()
+  const lastDataTime = lastPoint.timestamp.getTime()
+  
+  // Consider inference still running if last data point is within 1 minute of now
+  const isRunning = (now.getTime() - lastDataTime) < 60000
+  
+  // Use current time if running, otherwise use last data point time
+  const calculationTime = isRunning ? now : lastPoint.timestamp
+  
+  const totalTime = (calculationTime.getTime() - firstPoint.timestamp.getTime()) / 1000 / 60
   const totalCritics = lastPoint.critic1 + lastPoint.critic2 + lastPoint.critic3
   
   const avgSpeed = totalTime > 0 ? totalCritics / totalTime : 0
 
-  let currentSpeed = 0
-  const oneHourAgo = lastPoint.timestamp.getTime() - 3600000
-  const pointOneHourAgo = data.find(d => d.timestamp.getTime() >= oneHourAgo) || firstPoint
-  
-  if (pointOneHourAgo) {
-    const timeDiff = (lastPoint.timestamp.getTime() - pointOneHourAgo.timestamp.getTime()) / 1000 / 60
-    const currentCritics = totalCritics
-    const oldCritics = pointOneHourAgo.critic1 + pointOneHourAgo.critic2 + pointOneHourAgo.critic3
-    currentSpeed = timeDiff > 0 ? (currentCritics - oldCritics) / timeDiff : 0
+  let currentSpeed: number | string = '-'
+  if (isRunning) {
+    const oneHourAgo = calculationTime.getTime() - 3600000
+    const pointOneHourAgo = data.find(d => d.timestamp.getTime() >= oneHourAgo) || firstPoint
+    
+    if (pointOneHourAgo) {
+      const timeDiff = (calculationTime.getTime() - pointOneHourAgo.timestamp.getTime()) / 1000 / 60
+      const currentCritics = totalCritics
+      const oldCritics = pointOneHourAgo.critic1 + pointOneHourAgo.critic2 + pointOneHourAgo.critic3
+      currentSpeed = timeDiff > 0 ? (currentCritics - oldCritics) / timeDiff : 0
+    }
   }
 
   return (
@@ -317,7 +329,9 @@ function SpeedStats({ data }: SpeedStatsProps) {
       </div>
       <div>
         <span className="text-oh-text-muted">Current Speed:</span>{' '}
-        <span className="font-mono text-oh-text">{currentSpeed.toFixed(2)} instances/min</span>
+        <span className="font-mono text-oh-text">
+          {typeof currentSpeed === 'number' ? `${currentSpeed.toFixed(2)} instances/min` : '-'}
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

This PR fixes issue #129 by updating the `InferProgressGraph` component to properly handle speed calculations during and after inference completion.

### Changes Made

1. **During Inference**:
   - Average Speed and Current Speed now use the current UTC time for calculations
   - This ensures real-time accuracy while inference is running

2. **After Inference Completes**:
   - Current Speed displays "-" to indicate no active inference
   - Average Speed continues to show the calculated value based on actual inference duration

### Implementation Details

The `SpeedStats` component was updated to:
- Determine if inference is still running by checking if the last data point is within 1 minute of the current time
- Use `new Date()` to get the current UTC time during active inference
- Fall back to the last data point's timestamp when inference has completed

### Testing

Added two new tests to verify the behavior:
1. `shows Current Speed as "-" when inference is complete` - Verifies that old data shows "-" for Current Speed
2. `calculates speeds using current time when inference is running` - Verifies numeric values are shown during active inference

All 292 tests pass.

## Fixes

Fixes #129

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4ba01c73-837b-4f43-aa7c-eb20686e8121)