### PR TITLE
Show reason field in cancelled section of run detail page

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -586,6 +586,63 @@ describe('RunDetailView', () => {
       const helmEl = screen.getByTestId('helm-releases-found')
       expect(helmEl.textContent).toContain('4')
     })
+
+    it('shows reason when present in cancelEval', () => {
+      const metadata = makeMetadata({
+        cancelEval: {
+          timestamp: '2025-03-15T10:45:00Z',
+          cancelled_by: 'alice',
+          reason: 'seems stuck in build images stage, running another one',
+        },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      const reasonEl = screen.getByTestId('cancelled-reason')
+      expect(reasonEl.textContent).toContain('Reason:')
+      expect(reasonEl.textContent).toContain('seems stuck in build images stage, running another one')
+    })
+
+    it('does not show reason when absent from cancelEval', () => {
+      const metadata = makeMetadata({
+        cancelEval: {
+          timestamp: '2025-03-15T10:45:00Z',
+          cancelled_by: 'alice',
+        },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      expect(screen.queryByTestId('cancelled-reason')).toBeNull()
+    })
+
+    it('does not show reason when reason is empty string', () => {
+      const metadata = makeMetadata({
+        cancelEval: {
+          timestamp: '2025-03-15T10:45:00Z',
+          cancelled_by: 'alice',
+          reason: '',
+        },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      expect(screen.queryByTestId('cancelled-reason')).toBeNull()
+    })
+
+    it('does not show reason when reason is not a string', () => {
+      const metadata = makeMetadata({
+        cancelEval: {
+          timestamp: '2025-03-15T10:45:00Z',
+          cancelled_by: 'alice',
+          reason: 123,
+        },
+      })
+      render(
+        <RunDetailView slug={defaultSlug} metadata={metadata} loading={false} status="cancelled" />
+      )
+      expect(screen.queryByTestId('cancelled-reason')).toBeNull()
+    })
   })
 
   describe('Submission badge', () => {

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -148,6 +148,12 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
                       {String(metadata.cancelEval.helm_releases_found)}
                     </span>
                   )}
+                  {typeof metadata.cancelEval.reason === 'string' && metadata.cancelEval.reason && (
+                    <span data-testid="cancelled-reason">
+                      <span className="font-medium">Reason:</span>{' '}
+                      {metadata.cancelEval.reason}
+                    </span>
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

This PR adds display of the `reason` field from `cancel-eval.json` in the cancelled section of the run detail page. When a cancelled evaluation includes a reason (e.g., "seems stuck in build images stage, running another one"), it will now be displayed alongside other cancellation metadata.

## Changes

- **frontend/src/components/RunDetailView.tsx**: Added conditional rendering of the `reason` field in the cancelled section, with proper type checking (only displays if it is a non-empty string)
- **frontend/src/__tests__/RunDetailView.test.tsx**: Added 4 test cases covering:
  - Displaying the reason when present
  - Not showing when reason is absent
  - Not showing when reason is an empty string
  - Not showing when reason is not a string type

## Screenshots

The cancelled section will now show:
```
Evaluation Cancelled

Cancelled at: 4/6/2026, 10:45:00 AM
Cancelled by: alice
Reason: seems stuck in build images stage, running another one
```

## Fixes

Fixes #133