### PR TITLE
feat: Add clusterHealth URL parameter for direct linking to Cluster Health modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ function getTodayUTC(): string {
   return now.toISOString().split('T')[0]
 }
 
-export function parseSearchParams(search: string, defaultDate: string): { date: string; run: string | null; numDays: number; filterBenchmark: string; filterStatus: string; filterText: string } {
+export function parseSearchParams(search: string, defaultDate: string): { date: string; run: string | null; numDays: number; filterBenchmark: string; filterStatus: string; filterText: string; clusterHealth: boolean } {
   const params = new URLSearchParams(search)
   const date = params.get('date') || defaultDate
   const run = params.get('run') || null
@@ -19,10 +19,11 @@ export function parseSearchParams(search: string, defaultDate: string): { date: 
   const filterBenchmark = params.get('benchmark') || 'all'
   const filterStatus = params.get('status') || 'all'
   const filterText = params.get('text') || ''
-  return { date, run, numDays, filterBenchmark, filterStatus, filterText }
+  const clusterHealth = params.get('clusterHealth') === 'true'
+  return { date, run, numDays, filterBenchmark, filterStatus, filterText, clusterHealth }
 }
 
-export function buildSearchString(date: string, run: string | null, todayDate: string, numDays: number = 3, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = ''): string {
+export function buildSearchString(date: string, run: string | null, todayDate: string, numDays: number = 3, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = '', clusterHealth: boolean = false): string {
   const params = new URLSearchParams()
   if (date !== todayDate) {
     params.set('date', date)
@@ -42,6 +43,9 @@ export function buildSearchString(date: string, run: string | null, todayDate: s
   if (filterText) {
     params.set('text', filterText)
   }
+  if (clusterHealth) {
+    params.set('clusterHealth', 'true')
+  }
   const qs = params.toString()
   return qs ? `?${qs}` : ''
 }
@@ -50,8 +54,8 @@ function parseUrlState() {
   return parseSearchParams(window.location.search, getTodayUTC())
 }
 
-function buildUrl(date: string, run: string | null, numDays: number, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = ''): string {
-  const qs = buildSearchString(date, run, getTodayUTC(), numDays, filterBenchmark, filterStatus, filterText)
+function buildUrl(date: string, run: string | null, numDays: number, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = '', clusterHealth: boolean = false): string {
+  const qs = buildSearchString(date, run, getTodayUTC(), numDays, filterBenchmark, filterStatus, filterText, clusterHealth)
   return qs || window.location.pathname
 }
 
@@ -62,6 +66,7 @@ export default function App() {
   const [filterBenchmark, setFilterBenchmark] = useState(initialState.filterBenchmark)
   const [filterStatus, setFilterStatus] = useState(initialState.filterStatus)
   const [filterText, setFilterText] = useState(initialState.filterText)
+  const [clusterHealthOpen, setClusterHealthOpen] = useState(initialState.clusterHealth)
   
   const [runs, setRuns] = useState<RunListItem[]>([])
   const [dayGroups, setDayGroups] = useState<DayRunGroup[]>([])
@@ -83,9 +88,9 @@ export default function App() {
       setInitialized(true)
       return
     }
-    const url = buildUrl(date, selectedRun, numDays, filterBenchmark, filterStatus, filterText)
-    window.history.pushState({ date, run: selectedRun, numDays, filterBenchmark, filterStatus, filterText }, '', url)
-  }, [date, selectedRun, numDays, filterBenchmark, filterStatus, filterText]) // eslint-disable-line react-hooks/exhaustive-deps
+    const url = buildUrl(date, selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealthOpen)
+    window.history.pushState({ date, run: selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealth: clusterHealthOpen }, '', url)
+  }, [date, selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealthOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle browser back/forward navigation
   useEffect(() => {
@@ -97,6 +102,7 @@ export default function App() {
       setFilterBenchmark(state.filterBenchmark)
       setFilterStatus(state.filterStatus)
       setFilterText(state.filterText)
+      setClusterHealthOpen(state.clusterHealth)
       if (!state.run) {
         setRunMetadata(null)
       }
@@ -231,6 +237,8 @@ export default function App() {
         numDays={numDays}
         onNumDaysChange={setNumDays}
         refreshNonce={refreshNonce}
+        clusterHealthOpen={clusterHealthOpen}
+        onClusterHealthToggle={setClusterHealthOpen}
       />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">

--- a/frontend/src/__tests__/Header.test.tsx
+++ b/frontend/src/__tests__/Header.test.tsx
@@ -11,6 +11,8 @@ const defaultProps = {
   numDays: 2,
   onNumDaysChange: vi.fn(),
   refreshNonce: 0,
+  clusterHealthOpen: false,
+  onClusterHealthToggle: vi.fn(),
 }
 
 // ClusterHealthBadge fetches on mount; stub fetch per-test so we don't hit the

--- a/frontend/src/__tests__/url-routing.test.ts
+++ b/frontend/src/__tests__/url-routing.test.ts
@@ -6,37 +6,37 @@ describe('parseSearchParams', () => {
 
   it('returns defaults when search string is empty', () => {
     const result = parseSearchParams('', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('parses date from search params', () => {
     const result = parseSearchParams('?date=2025-01-15', defaultDate)
-    expect(result).toEqual({ date: '2025-01-15', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-01-15', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('parses run from search params', () => {
     const result = parseSearchParams('?run=swebench/model/123', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('parses both date and run from search params', () => {
     const result = parseSearchParams('?date=2025-02-20&run=gaia/litellm_proxy-gpt4/456', defaultDate)
-    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('handles URL-encoded run slugs with slashes', () => {
     const result = parseSearchParams('?run=bench%2Fmodel%2Fjob', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('uses default date when date param is missing', () => {
     const result = parseSearchParams('?run=test/run/1', '2025-12-31')
-    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('parses days param', () => {
     const result = parseSearchParams('?days=3', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('clamps days param to valid range (1-7)', () => {
@@ -49,12 +49,22 @@ describe('parseSearchParams', () => {
 
   it('parses date, run, and days together', () => {
     const result = parseSearchParams('?date=2025-02-20&run=gaia/model/1&days=5', defaultDate)
-    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/model/1', numDays: 5, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/model/1', numDays: 5, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('parses filters', () => {
     const result = parseSearchParams('?benchmark=swebench&status=completed&text=gpt4', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4' })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: false })
+  })
+
+  it('parses clusterHealth=true from search params', () => {
+    const result = parseSearchParams('?clusterHealth=true', defaultDate)
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: true })
+  })
+
+  it('parses clusterHealth with other params', () => {
+    const result = parseSearchParams('?date=2025-02-20&clusterHealth=true&benchmark=swebench', defaultDate)
+    expect(result).toEqual({ date: '2025-02-20', run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'all', filterText: '', clusterHealth: true })
   })
 })
 
@@ -110,6 +120,21 @@ describe('buildSearchString', () => {
     const result = buildSearchString('2025-02-20', 'gaia/model/1', today, 5)
     expect(result).toBe('?date=2025-02-20&run=gaia%2Fmodel%2F1&days=5')
   })
+
+  it('omits clusterHealth param when false (default)', () => {
+    const result = buildSearchString(today, null, today, 3, 'all', 'all', '', false)
+    expect(result).toBe('')
+  })
+
+  it('includes clusterHealth param when true', () => {
+    const result = buildSearchString(today, null, today, 3, 'all', 'all', '', true)
+    expect(result).toBe('?clusterHealth=true')
+  })
+
+  it('includes clusterHealth with other params', () => {
+    const result = buildSearchString(today, null, today, 3, 'swebench', 'all', '', true)
+    expect(result).toBe('?benchmark=swebench&clusterHealth=true')
+  })
 })
 
 describe('round-trip: buildSearchString -> parseSearchParams', () => {
@@ -120,27 +145,27 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     const run = 'swebench/litellm_proxy-claude/789'
     const qs = buildSearchString(date, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(parsed).toEqual({ date, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('round-trips a run selection with today date', () => {
     const run = 'gaia/model/42'
     const qs = buildSearchString(today, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(parsed).toEqual({ date: today, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('round-trips list view with non-today date', () => {
     const date = '2025-06-15'
     const qs = buildSearchString(date, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(parsed).toEqual({ date, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('round-trips list view with today date', () => {
     const qs = buildSearchString(today, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('round-trips with numDays > 3', () => {
@@ -149,24 +174,38 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     const numDays = 5
     const qs = buildSearchString(date, run, today, numDays)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run, numDays, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(parsed).toEqual({ date, run, numDays, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('round-trips with numDays = 3 (default omitted)', () => {
     const qs = buildSearchString(today, null, today, 3)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('round-trips with numDays = 1', () => {
     const qs = buildSearchString(today, null, today, 1)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 1, filterBenchmark: 'all', filterStatus: 'all', filterText: '' })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 1, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
   })
 
   it('round-trips with filters', () => {
     const qs = buildSearchString(today, null, today, 3, 'swebench', 'completed', 'gpt4')
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4' })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: false })
+  })
+
+  it('round-trips with clusterHealth=true', () => {
+    const qs = buildSearchString(today, null, today, 3, 'all', 'all', '', true)
+    const parsed = parseSearchParams(qs, today)
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: true })
+  })
+
+  it('round-trips clusterHealth with other params', () => {
+    const date = '2025-02-20'
+    const run = 'swebench/model/123'
+    const qs = buildSearchString(date, run, today, 5, 'swebench', 'completed', 'gpt4', true)
+    const parsed = parseSearchParams(qs, today)
+    expect(parsed).toEqual({ date, run, numDays: 5, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: true })
   })
 })

--- a/frontend/src/components/ClusterHealthBadge.tsx
+++ b/frontend/src/components/ClusterHealthBadge.tsx
@@ -6,12 +6,25 @@ import ClusterHealthModal from './ClusterHealth/ClusterHealthModal'
 
 interface Props {
   refreshNonce: number
+  isOpen?: boolean
+  onToggle?: (open: boolean) => void
 }
 
-export default function ClusterHealthBadge({ refreshNonce }: Props) {
+export default function ClusterHealthBadge({ refreshNonce, isOpen: controlledOpen, onToggle }: Props) {
   const [report, setReport] = useState<ClusterHealthReport | null>(null)
   const [loading, setLoading] = useState(true)
-  const [open, setOpen] = useState(false)
+  const [internalOpen, setInternalOpen] = useState(false)
+
+  const isControlled = controlledOpen !== undefined && onToggle !== undefined
+  const open = isControlled ? controlledOpen : internalOpen
+
+  const handleToggle = (newOpen: boolean) => {
+    if (isControlled) {
+      onToggle(newOpen)
+    } else {
+      setInternalOpen(newOpen)
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -47,9 +60,9 @@ export default function ClusterHealthBadge({ refreshNonce }: Props) {
         labelClass={styles.label}
         label={badgeLabel}
         title={`Updated ${formatAge(report.timestamp)}`}
-        onClick={() => setOpen(true)}
+        onClick={() => handleToggle(true)}
       />
-      {open && <ClusterHealthModal report={report} onClose={() => setOpen(false)} />}
+      {open && <ClusterHealthModal report={report} onClose={() => handleToggle(false)} />}
     </>
   )
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -9,9 +9,11 @@ interface HeaderProps {
   numDays: number
   onNumDaysChange: (days: number) => void
   refreshNonce: number
+  clusterHealthOpen: boolean
+  onClusterHealthToggle: (open: boolean) => void
 }
 
-export default function Header({ date, onDateChange, onRefresh, selectedRun, onBack, numDays, onNumDaysChange, refreshNonce }: HeaderProps) {
+export default function Header({ date, onDateChange, onRefresh, selectedRun, onBack, numDays, onNumDaysChange, refreshNonce, clusterHealthOpen, onClusterHealthToggle }: HeaderProps) {
   const handlePrevDay = () => {
     const d = new Date(date + 'T00:00:00Z')
     d.setUTCDate(d.getUTCDate() - 1)
@@ -122,7 +124,7 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
 
           {/* Right: Cluster health + Refresh */}
           <div className="flex items-center gap-2">
-            {!selectedRun && <ClusterHealthBadge refreshNonce={refreshNonce} />}
+            {!selectedRun && <ClusterHealthBadge refreshNonce={refreshNonce} isOpen={clusterHealthOpen} onToggle={onClusterHealthToggle} />}
           <button
             onClick={onRefresh}
             className="p-2 rounded-lg text-oh-text-muted hover:text-oh-text hover:bg-oh-surface-hover transition-colors"


### PR DESCRIPTION
## Summary

This PR adds support for linking directly to the Cluster Health modal via URL parameter `?clusterHealth=true`.

## Changes

- Add `clusterHealth` param to `parseSearchParams` and `buildSearchString` functions in `App.tsx`
- Add `clusterHealthOpen` state in `App.tsx` and sync with URL (including browser back/forward navigation)
- Update `Header.tsx` to pass `clusterHealthOpen` and `onClusterHealthToggle` props to `ClusterHealthBadge`
- Update `ClusterHealthBadge.tsx` to support controlled mode with `isOpen` and `onToggle` props
- Add tests for `clusterHealth` URL parameter parsing and building

## How to use

Simply add `?clusterHealth=true` to any eval-monitor URL to automatically open the Cluster Health modal. For example:
```
https://eval.all-hands.dev/?clusterHealth=true
https://eval.all-hands.dev/?date=2026-01-15&clusterHealth=true
```

## Fixes

Fixes #146

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ea2abc98-1a6a-4b7d-9087-0da3cf78fbec)