### PR TITLE
Add submit to index button to results section

### DIFF
--- a/frontend/src/__tests__/CompletedRunResults.test.tsx
+++ b/frontend/src/__tests__/CompletedRunResults.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import CompletedRunResults from '../components/CompletedRunResults'
 
 const originalFetch = globalThis.fetch
@@ -69,5 +69,55 @@ describe('CompletedRunResults', () => {
 
     await screen.findByText('Cost Report')
     expect(screen.queryByTestId('zero-cost-warning')).toBeNull()
+  })
+
+  describe('Submit to index button', () => {
+    const originalOpen = window.open
+
+    beforeEach(() => {
+      window.open = vi.fn()
+    })
+
+    afterEach(() => {
+      window.open = originalOpen
+      globalThis.fetch = originalFetch
+      vi.restoreAllMocks()
+    })
+
+    it('renders the submit to index button', async () => {
+      mockFetchWithCost(1.2345)
+
+      render(<CompletedRunResults slug="swebench/model/123" />)
+
+      await screen.findByText('Copy archive link and submit to index')
+    })
+
+    it('copies archive URL to clipboard and opens push-to-index workflow when clicked', async () => {
+      mockFetchWithCost(1.2345)
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { clipboard: { writeText } })
+
+      render(<CompletedRunResults slug="swebench/model/123" />)
+
+      const button = await screen.findByText('Copy archive link and submit to index')
+      await act(async () => {
+        fireEvent.click(button)
+      })
+
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('results.tar.gz'))
+      expect(window.open).toHaveBeenCalledWith(
+        'https://github.com/OpenHands/evaluation/actions/workflows/push-to-index.yml',
+        '_blank'
+      )
+    })
+
+    it('renders both download and submit to index buttons', async () => {
+      mockFetchWithCost(1.2345)
+
+      render(<CompletedRunResults slug="swebench/model/123" />)
+
+      await screen.findByText('Download results.tar.gz')
+      await screen.findByText('Copy archive link and submit to index')
+    })
   })
 })

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -123,13 +123,20 @@ function CostReportCard({ report }: { report: CostReport }) {
 
 function ArchiveLink({ slug }: { slug: string }) {
   const archiveUrl = getResultsUrl(slug, 'results.tar.gz')
+  const PUSH_TO_INDEX_URL = 'https://github.com/OpenHands/evaluation/actions/workflows/push-to-index.yml'
+
+  const handleCopyAndOpen = async () => {
+    await navigator.clipboard.writeText(archiveUrl)
+    window.open(PUSH_TO_INDEX_URL, '_blank')
+  }
+
   return (
     <div className="bg-oh-surface border border-oh-border rounded-lg p-4">
       <div className="flex items-center gap-2">
         <span>📦</span>
         <h3 className="text-sm font-medium text-oh-text">Results Archive</h3>
       </div>
-      <div className="mt-3">
+      <div className="mt-3 flex items-center gap-2 flex-wrap">
         <a
           href={archiveUrl}
           target="_blank"
@@ -141,6 +148,15 @@ function ArchiveLink({ slug }: { slug: string }) {
           </svg>
           Download results.tar.gz
         </a>
+        <button
+          onClick={handleCopyAndOpen}
+          className="inline-flex items-center gap-2 px-3 py-1.5 bg-oh-warning/10 text-oh-warning border border-oh-warning/30 rounded-md text-sm font-medium hover:bg-oh-warning/20 transition-colors cursor-pointer"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+          </svg>
+          Copy archive link and submit to index
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Added a 'Copy archive link and submit to index' button to the Results Archive section. This button:

1. Copies the archive URL (results.tar.gz) to the clipboard
2. Opens https://github.com/OpenHands/evaluation/actions/workflows/push-to-index.yml in a new tab

The implementation follows the same pattern as the 'Copy Id and Open Cancel Action' button found in the Cancel Evaluation section.

## Changes

- `frontend/src/components/CompletedRunResults.tsx`: Added the submit to index button next to the download button in the `ArchiveLink` component
- `frontend/src/__tests__/CompletedRunResults.test.tsx`: Added tests to verify:
  - The button is rendered
  - Clicking the button copies the archive URL and opens the workflow URL
  - Both buttons (download and submit) are present

Fixes #148