### PR TITLE
feat: eval time monitor

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ function getTodayUTC(): string {
   return now.toISOString().split('T')[0]
 }
 
-export function parseSearchParams(search: string, defaultDate: string): { date: string; run: string | null; numDays: number; filterBenchmark: string; filterStatus: string; filterText: string; clusterHealth: boolean } {
+export function parseSearchParams(search: string, defaultDate: string): { date: string; run: string | null; numDays: number; filterBenchmark: string; filterStatus: string; filterText: string; clusterHealth: boolean; evalTime: boolean } {
   const params = new URLSearchParams(search)
   const date = params.get('date') || defaultDate
   const run = params.get('run') || null
@@ -20,10 +20,11 @@ export function parseSearchParams(search: string, defaultDate: string): { date: 
   const filterStatus = params.get('status') || 'all'
   const filterText = params.get('text') || ''
   const clusterHealth = params.get('clusterHealth') === 'true'
-  return { date, run, numDays, filterBenchmark, filterStatus, filterText, clusterHealth }
+  const evalTime = params.get('evalTime') === 'true'
+  return { date, run, numDays, filterBenchmark, filterStatus, filterText, clusterHealth, evalTime }
 }
 
-export function buildSearchString(date: string, run: string | null, todayDate: string, numDays: number = 3, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = '', clusterHealth: boolean = false): string {
+export function buildSearchString(date: string, run: string | null, todayDate: string, numDays: number = 3, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = '', clusterHealth: boolean = false, evalTime: boolean = false): string {
   const params = new URLSearchParams()
   if (date !== todayDate) {
     params.set('date', date)
@@ -46,6 +47,9 @@ export function buildSearchString(date: string, run: string | null, todayDate: s
   if (clusterHealth) {
     params.set('clusterHealth', 'true')
   }
+  if (evalTime) {
+    params.set('evalTime', 'true')
+  }
   const qs = params.toString()
   return qs ? `?${qs}` : ''
 }
@@ -54,8 +58,8 @@ function parseUrlState() {
   return parseSearchParams(window.location.search, getTodayUTC())
 }
 
-function buildUrl(date: string, run: string | null, numDays: number, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = '', clusterHealth: boolean = false): string {
-  const qs = buildSearchString(date, run, getTodayUTC(), numDays, filterBenchmark, filterStatus, filterText, clusterHealth)
+function buildUrl(date: string, run: string | null, numDays: number, filterBenchmark: string = 'all', filterStatus: string = 'all', filterText: string = '', clusterHealth: boolean = false, evalTime: boolean = false): string {
+  const qs = buildSearchString(date, run, getTodayUTC(), numDays, filterBenchmark, filterStatus, filterText, clusterHealth, evalTime)
   return qs || window.location.pathname
 }
 
@@ -67,7 +71,8 @@ export default function App() {
   const [filterStatus, setFilterStatus] = useState(initialState.filterStatus)
   const [filterText, setFilterText] = useState(initialState.filterText)
   const [clusterHealthOpen, setClusterHealthOpen] = useState(initialState.clusterHealth)
-  
+  const [evalTimeOpen, setEvalTimeOpen] = useState(initialState.evalTime)
+
   const [runs, setRuns] = useState<RunListItem[]>([])
   const [dayGroups, setDayGroups] = useState<DayRunGroup[]>([])
   const [loading, setLoading] = useState(true)
@@ -88,9 +93,9 @@ export default function App() {
       setInitialized(true)
       return
     }
-    const url = buildUrl(date, selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealthOpen)
-    window.history.pushState({ date, run: selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealth: clusterHealthOpen }, '', url)
-  }, [date, selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealthOpen]) // eslint-disable-line react-hooks/exhaustive-deps
+    const url = buildUrl(date, selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealthOpen, evalTimeOpen)
+    window.history.pushState({ date, run: selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealth: clusterHealthOpen, evalTime: evalTimeOpen }, '', url)
+  }, [date, selectedRun, numDays, filterBenchmark, filterStatus, filterText, clusterHealthOpen, evalTimeOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle browser back/forward navigation
   useEffect(() => {
@@ -103,6 +108,7 @@ export default function App() {
       setFilterStatus(state.filterStatus)
       setFilterText(state.filterText)
       setClusterHealthOpen(state.clusterHealth)
+      setEvalTimeOpen(state.evalTime)
       if (!state.run) {
         setRunMetadata(null)
       }
@@ -239,6 +245,11 @@ export default function App() {
         refreshNonce={refreshNonce}
         clusterHealthOpen={clusterHealthOpen}
         onClusterHealthToggle={setClusterHealthOpen}
+        evalTimeOpen={evalTimeOpen}
+        onEvalTimeToggle={setEvalTimeOpen}
+        runMetadataMap={runMetadataMap}
+        runs={runs}
+        onSelectRun={handleSelectRun}
       />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">

--- a/frontend/src/__tests__/Header.test.tsx
+++ b/frontend/src/__tests__/Header.test.tsx
@@ -13,6 +13,10 @@ const defaultProps = {
   refreshNonce: 0,
   clusterHealthOpen: false,
   onClusterHealthToggle: vi.fn(),
+  evalTimeOpen: false,
+  onEvalTimeToggle: vi.fn(),
+  runMetadataMap: {},
+  runs: [],
 }
 
 // ClusterHealthBadge fetches on mount; stub fetch per-test so we don't hit the

--- a/frontend/src/__tests__/eval-time.test.ts
+++ b/frontend/src/__tests__/eval-time.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect } from 'vitest'
+import { computeEvalTimeReport, EVAL_TIME_WARNING_MS, EVAL_TIME_CRITICAL_MS } from '../api'
+import type { RunMetadata, RunListItemStatus } from '../api'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a RunMetadata where every field is null by default. Pass overrides to
+ *  set specific stage records, each optionally carrying a timestamp. */
+function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
+  return {
+    init: null,
+    params: null,
+    error: null,
+    runInferStart: null,
+    runInferEnd: null,
+    evalInferStart: null,
+    evalInferEnd: null,
+    cancelEval: null,
+    ...overrides,
+  }
+}
+
+/** Return an ISO timestamp string that is `offsetMs` milliseconds before `now`. */
+function tsAgo(now: number, offsetMs: number): string {
+  return new Date(now - offsetMs).toISOString()
+}
+
+// A fixed "now" used throughout so elapsed times are deterministic.
+const NOW = 1_700_000_000_000
+
+// Convenient elapsed-time constants relative to the thresholds.
+const UNDER_WARNING = EVAL_TIME_WARNING_MS - 1          // 1 ms under 10 h
+const AT_WARNING    = EVAL_TIME_WARNING_MS              // exactly 10 h
+const BETWEEN       = EVAL_TIME_WARNING_MS + 1_000_000  // ~10 h 16 m 40 s
+const AT_CRITICAL   = EVAL_TIME_CRITICAL_MS             // exactly 24 h
+const OVER_CRITICAL = EVAL_TIME_CRITICAL_MS + 1         // 1 ms over 24 h
+
+// ---------------------------------------------------------------------------
+// computeEvalTimeReport
+// ---------------------------------------------------------------------------
+
+describe('computeEvalTimeReport', () => {
+
+  // -------------------------------------------------------------------------
+  // Empty / trivial input
+  // -------------------------------------------------------------------------
+
+  describe('empty metadataMap', () => {
+    it('returns healthy state with zero entries and zero totalActive', () => {
+      const report = computeEvalTimeReport({}, {}, NOW)
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Finished runs are skipped entirely
+  // -------------------------------------------------------------------------
+
+  describe('finished runs', () => {
+    it('skips completed runs', () => {
+      const metadata = makeMetadata({ evalInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(0)
+    })
+
+    it('skips error runs', () => {
+      const metadata = makeMetadata({ error: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(0)
+    })
+
+    it('skips cancelled runs', () => {
+      const metadata = makeMetadata({ cancelEval: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(0)
+    })
+
+    it('skips all three finished statuses and reports zero totalActive', () => {
+      const completed = makeMetadata({ evalInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const errored   = makeMetadata({ error: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const cancelled = makeMetadata({ cancelEval: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport(
+        { 'a/b/1': completed, 'a/b/2': errored, 'a/b/3': cancelled },
+        {},
+        NOW,
+      )
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Active run under the warning threshold → healthy
+  // -------------------------------------------------------------------------
+
+  describe('active run under warning threshold', () => {
+    it('counts the run in totalActive but emits no entries and stays healthy', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, UNDER_WARNING) } })
+      // getStageStatus will return 'building' (params present, nothing else)
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Threshold boundary: warning
+  // -------------------------------------------------------------------------
+
+  describe('warning threshold boundary', () => {
+    it('triggers warning when elapsed equals EVAL_TIME_WARNING_MS exactly', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('warning')
+      expect(report.entries).toHaveLength(1)
+      expect(report.entries[0].elapsedMs).toBe(AT_WARNING)
+      expect(report.totalActive).toBe(1)
+    })
+
+    it('emits an entry for a run between warning and critical thresholds', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, BETWEEN) } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('warning')
+      expect(report.entries).toHaveLength(1)
+      expect(report.entries[0].elapsedMs).toBe(BETWEEN)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Threshold boundary: critical
+  // -------------------------------------------------------------------------
+
+  describe('critical threshold boundary', () => {
+    it('triggers critical when elapsed equals EVAL_TIME_CRITICAL_MS exactly', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('critical')
+      expect(report.entries).toHaveLength(1)
+      expect(report.entries[0].elapsedMs).toBe(AT_CRITICAL)
+    })
+
+    it('triggers critical when elapsed exceeds EVAL_TIME_CRITICAL_MS', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('critical')
+      expect(report.entries).toHaveLength(1)
+      expect(report.entries[0].elapsedMs).toBe(OVER_CRITICAL)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Mixed warning + critical → overall state is critical
+  // -------------------------------------------------------------------------
+
+  describe('mix of warning and critical entries', () => {
+    it('reports critical when any entry reaches EVAL_TIME_CRITICAL_MS', () => {
+      const warnRun     = makeMetadata({ params: { timestamp: tsAgo(NOW, BETWEEN) } })
+      const criticalRun = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
+      const report = computeEvalTimeReport(
+        { 'slug/warn/1': warnRun, 'slug/crit/1': criticalRun },
+        {},
+        NOW,
+      )
+      expect(report.state).toBe('critical')
+      expect(report.entries).toHaveLength(2)
+      expect(report.totalActive).toBe(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Sorting: longest-running first
+  // -------------------------------------------------------------------------
+
+  describe('sorting', () => {
+    it('returns entries sorted longest elapsed time first', () => {
+      const slow     = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
+      const moderate = makeMetadata({ params: { timestamp: tsAgo(NOW, BETWEEN) } })
+      const fastest  = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
+      const report = computeEvalTimeReport(
+        { 'slug/fast/1': fastest, 'slug/slow/1': slow, 'slug/mod/1': moderate },
+        {},
+        NOW,
+      )
+      expect(report.entries[0].elapsedMs).toBeGreaterThanOrEqual(report.entries[1].elapsedMs)
+      expect(report.entries[1].elapsedMs).toBeGreaterThanOrEqual(report.entries[2].elapsedMs)
+      // The absolute values must match too
+      expect(report.entries[0].elapsedMs).toBe(AT_CRITICAL)
+      expect(report.entries[1].elapsedMs).toBe(BETWEEN)
+      expect(report.entries[2].elapsedMs).toBe(AT_WARNING)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Stage labels
+  // -------------------------------------------------------------------------
+
+  describe('stageLabel per status', () => {
+    it('produces "Building" for building status', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
+      // getStageStatus → 'building' (params present, no other signals)
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.entries[0].stageLabel).toBe('Building')
+      expect(report.entries[0].status).toBe('building')
+    })
+
+    it('produces "Inference" for running-infer status', () => {
+      const metadata = makeMetadata({
+        params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+        init: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+        runInferStart: { timestamp: tsAgo(NOW, AT_WARNING) },
+      })
+      // getStageStatus → 'running-infer' (runInferStart present, no runInferEnd)
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.entries[0].stageLabel).toBe('Inference')
+      expect(report.entries[0].status).toBe('running-infer')
+    })
+
+    it('produces "Evaluation" for running-eval status via evalInferStart', () => {
+      const metadata = makeMetadata({
+        params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+        runInferStart: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+        runInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+        evalInferStart: { timestamp: tsAgo(NOW, AT_WARNING) },
+      })
+      // getStageStatus → 'running-eval' (evalInferStart present, no evalInferEnd)
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.entries[0].stageLabel).toBe('Evaluation')
+      expect(report.entries[0].status).toBe('running-eval')
+    })
+
+    it('produces "Pending" for pending status', () => {
+      const metadata = makeMetadata({ init: { timestamp: tsAgo(NOW, AT_WARNING) } })
+      // getStageStatus → 'pending' (init present, no params)
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.entries[0].stageLabel).toBe('Pending')
+      expect(report.entries[0].status).toBe('pending')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Stage start timestamp selection
+  // -------------------------------------------------------------------------
+
+  describe('stageStartMs timestamp selection', () => {
+    describe('building stage uses params.timestamp', () => {
+      it('uses params.timestamp as the start time for building runs', () => {
+        const startMs = AT_WARNING + 5000
+        const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, startMs) } })
+        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+        expect(report.entries[0].elapsedMs).toBe(startMs)
+      })
+    })
+
+    describe('running-infer stage uses runInferStart.timestamp', () => {
+      it('uses runInferStart.timestamp as the start time', () => {
+        const startMs = AT_WARNING + 7000
+        const metadata = makeMetadata({
+          params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+          init: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+          runInferStart: { timestamp: tsAgo(NOW, startMs) },
+        })
+        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+        expect(report.entries[0].status).toBe('running-infer')
+        expect(report.entries[0].elapsedMs).toBe(startMs)
+      })
+    })
+
+    describe('running-eval stage uses evalInferStart.timestamp with runInferEnd fallback', () => {
+      it('uses evalInferStart.timestamp when present', () => {
+        const startMs = AT_WARNING + 3000
+        const metadata = makeMetadata({
+          params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+          runInferStart: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+          runInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+          evalInferStart: { timestamp: tsAgo(NOW, startMs) },
+        })
+        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+        expect(report.entries[0].status).toBe('running-eval')
+        expect(report.entries[0].elapsedMs).toBe(startMs)
+      })
+
+      it('falls back to runInferEnd.timestamp when evalInferStart is absent', () => {
+        const startMs = AT_WARNING + 9000
+        const metadata = makeMetadata({
+          params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+          runInferStart: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+          runInferEnd: { timestamp: tsAgo(NOW, startMs) },
+          // evalInferStart is null — getStageStatus will still return 'running-eval'
+          // because runInferEnd is set
+        })
+        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+        expect(report.entries[0].status).toBe('running-eval')
+        expect(report.entries[0].elapsedMs).toBe(startMs)
+      })
+    })
+
+    describe('pending stage uses init.timestamp with params fallback', () => {
+      it('uses init.timestamp as the start time when present', () => {
+        const startMs = AT_WARNING + 2000
+        const metadata = makeMetadata({ init: { timestamp: tsAgo(NOW, startMs) } })
+        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+        expect(report.entries[0].status).toBe('pending')
+        expect(report.entries[0].elapsedMs).toBe(startMs)
+      })
+
+      it('falls back to params.timestamp when init has no timestamp', () => {
+        const startMs = AT_WARNING + 4000
+        const metadata = makeMetadata({
+          init: { some_other_field: 'value' },        // no timestamp
+          params: { timestamp: tsAgo(NOW, startMs) },
+        })
+        // getStageStatus: init present → 'pending'; stageStartMs: init ts null → falls back to params ts
+        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+        expect(report.entries[0].status).toBe('pending')
+        expect(report.entries[0].elapsedMs).toBe(startMs)
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // preStatuses override
+  // -------------------------------------------------------------------------
+
+  describe('preStatuses override', () => {
+    it('uses the preStatus instead of deriving status from metadata', () => {
+      // Metadata alone would indicate 'building' (only params present, no infer data).
+      // We override to 'running-infer', so stageStartMs will look at runInferStart.
+      const startMs = AT_WARNING + 1000
+      const metadata = makeMetadata({
+        params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
+        runInferStart: { timestamp: tsAgo(NOW, startMs) },
+      })
+      const report = computeEvalTimeReport(
+        { 'slug/a/1': metadata },
+        { 'slug/a/1': 'running-infer' },
+        NOW,
+      )
+      expect(report.entries[0].status).toBe('running-infer')
+      expect(report.entries[0].elapsedMs).toBe(startMs)
+    })
+
+    it('treats a run as finished when preStatus is completed, skipping it', () => {
+      // Metadata alone would derive 'building'; preStatus overrides to 'completed'.
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport(
+        { 'slug/a/1': metadata },
+        { 'slug/a/1': 'completed' },
+        NOW,
+      )
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(0)
+    })
+
+    it('treats a run as finished when preStatus is error, skipping it', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport(
+        { 'slug/a/1': metadata },
+        { 'slug/a/1': 'error' },
+        NOW,
+      )
+      expect(report.totalActive).toBe(0)
+    })
+
+    it('treats a run as finished when preStatus is cancelled, skipping it', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport(
+        { 'slug/a/1': metadata },
+        { 'slug/a/1': 'cancelled' },
+        NOW,
+      )
+      expect(report.totalActive).toBe(0)
+    })
+
+    it('only applies preStatus override to the matching slug', () => {
+      const slow    = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
+      const overridden = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
+      const report = computeEvalTimeReport(
+        { 'slug/slow/1': slow, 'slug/done/1': overridden },
+        { 'slug/done/1': 'completed' },
+        NOW,
+      )
+      // Only 'slug/slow/1' should remain active
+      expect(report.totalActive).toBe(1)
+      expect(report.entries).toHaveLength(1)
+      expect(report.entries[0].slug).toBe('slug/slow/1')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Missing timestamp → counted in totalActive but not in entries
+  // -------------------------------------------------------------------------
+
+  describe('run with no timestamp in stage metadata', () => {
+    it('counts the run in totalActive but excludes it from entries', () => {
+      // Status will be 'building' (params present), but params has no timestamp.
+      const metadata = makeMetadata({ params: { model_id: 'gpt-4' } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(1)
+    })
+
+    it('still counts correctly when mixed with slow runs that do have timestamps', () => {
+      const noTs = makeMetadata({ params: { model_id: 'gpt-4' } })
+      const slow = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
+      const report = computeEvalTimeReport(
+        { 'slug/no-ts/1': noTs, 'slug/slow/1': slow },
+        {},
+        NOW,
+      )
+      expect(report.totalActive).toBe(2)
+      expect(report.entries).toHaveLength(1)
+      expect(report.entries[0].slug).toBe('slug/slow/1')
+    })
+
+    it('treats an invalid (non-parseable) timestamp as missing', () => {
+      const metadata = makeMetadata({ params: { timestamp: 'not-a-date' } })
+      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Entry fields are correct
+  // -------------------------------------------------------------------------
+
+  describe('entry shape', () => {
+    it('populates all entry fields correctly', () => {
+      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
+      const report = computeEvalTimeReport({ 'bench/model/42': metadata }, {}, NOW)
+      const entry = report.entries[0]
+      expect(entry.slug).toBe('bench/model/42')
+      expect(entry.status).toBe('building')
+      expect(entry.stageLabel).toBe('Building')
+      expect(entry.elapsedMs).toBe(AT_WARNING)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // totalActive counts all non-finished runs regardless of threshold
+  // -------------------------------------------------------------------------
+
+  describe('totalActive count', () => {
+    it('includes active runs that are below the warning threshold in totalActive', () => {
+      const active1 = makeMetadata({ params: { timestamp: tsAgo(NOW, UNDER_WARNING) } })
+      const active2 = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
+      const report = computeEvalTimeReport(
+        { 'slug/a/1': active1, 'slug/b/1': active2 },
+        {},
+        NOW,
+      )
+      expect(report.totalActive).toBe(2)
+      // Only the run at the threshold shows in entries
+      expect(report.entries).toHaveLength(1)
+    })
+  })
+})

--- a/frontend/src/__tests__/eval-time.test.ts
+++ b/frontend/src/__tests__/eval-time.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { computeEvalTimeReport, EVAL_TIME_WARNING_MS, EVAL_TIME_CRITICAL_MS } from '../api'
-import type { RunMetadata, RunListItemStatus } from '../api'
+import type { RunMetadata } from '../api'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/frontend/src/__tests__/url-routing.test.ts
+++ b/frontend/src/__tests__/url-routing.test.ts
@@ -6,37 +6,37 @@ describe('parseSearchParams', () => {
 
   it('returns defaults when search string is empty', () => {
     const result = parseSearchParams('', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('parses date from search params', () => {
     const result = parseSearchParams('?date=2025-01-15', defaultDate)
-    expect(result).toEqual({ date: '2025-01-15', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-01-15', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('parses run from search params', () => {
     const result = parseSearchParams('?run=swebench/model/123', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-03-17', run: 'swebench/model/123', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('parses both date and run from search params', () => {
     const result = parseSearchParams('?date=2025-02-20&run=gaia/litellm_proxy-gpt4/456', defaultDate)
-    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/litellm_proxy-gpt4/456', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('handles URL-encoded run slugs with slashes', () => {
     const result = parseSearchParams('?run=bench%2Fmodel%2Fjob', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-03-17', run: 'bench/model/job', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('uses default date when date param is missing', () => {
     const result = parseSearchParams('?run=test/run/1', '2025-12-31')
-    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-12-31', run: 'test/run/1', numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('parses days param', () => {
     const result = parseSearchParams('?days=3', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('clamps days param to valid range (1-7)', () => {
@@ -49,22 +49,27 @@ describe('parseSearchParams', () => {
 
   it('parses date, run, and days together', () => {
     const result = parseSearchParams('?date=2025-02-20&run=gaia/model/1&days=5', defaultDate)
-    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/model/1', numDays: 5, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-02-20', run: 'gaia/model/1', numDays: 5, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('parses filters', () => {
     const result = parseSearchParams('?benchmark=swebench&status=completed&text=gpt4', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: false })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: false, evalTime: false })
   })
 
   it('parses clusterHealth=true from search params', () => {
     const result = parseSearchParams('?clusterHealth=true', defaultDate)
-    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: true })
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: true, evalTime: false })
   })
 
   it('parses clusterHealth with other params', () => {
     const result = parseSearchParams('?date=2025-02-20&clusterHealth=true&benchmark=swebench', defaultDate)
-    expect(result).toEqual({ date: '2025-02-20', run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'all', filterText: '', clusterHealth: true })
+    expect(result).toEqual({ date: '2025-02-20', run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'all', filterText: '', clusterHealth: true, evalTime: false })
+  })
+
+  it('parses evalTime=true from search params', () => {
+    const result = parseSearchParams('?evalTime=true', defaultDate)
+    expect(result).toEqual({ date: '2025-03-17', run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: true })
   })
 })
 
@@ -135,6 +140,11 @@ describe('buildSearchString', () => {
     const result = buildSearchString(today, null, today, 3, 'swebench', 'all', '', true)
     expect(result).toBe('?benchmark=swebench&clusterHealth=true')
   })
+
+  it('includes evalTime param when true', () => {
+    const result = buildSearchString(today, null, today, 3, 'all', 'all', '', false, true)
+    expect(result).toBe('?evalTime=true')
+  })
 })
 
 describe('round-trip: buildSearchString -> parseSearchParams', () => {
@@ -145,27 +155,27 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     const run = 'swebench/litellm_proxy-claude/789'
     const qs = buildSearchString(date, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(parsed).toEqual({ date, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips a run selection with today date', () => {
     const run = 'gaia/model/42'
     const qs = buildSearchString(today, run, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(parsed).toEqual({ date: today, run, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips list view with non-today date', () => {
     const date = '2025-06-15'
     const qs = buildSearchString(date, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(parsed).toEqual({ date, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips list view with today date', () => {
     const qs = buildSearchString(today, null, today)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips with numDays > 3', () => {
@@ -174,31 +184,31 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     const numDays = 5
     const qs = buildSearchString(date, run, today, numDays)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run, numDays, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(parsed).toEqual({ date, run, numDays, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips with numDays = 3 (default omitted)', () => {
     const qs = buildSearchString(today, null, today, 3)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips with numDays = 1', () => {
     const qs = buildSearchString(today, null, today, 1)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 1, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 1, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips with filters', () => {
     const qs = buildSearchString(today, null, today, 3, 'swebench', 'completed', 'gpt4')
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: false })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: false, evalTime: false })
   })
 
   it('round-trips with clusterHealth=true', () => {
     const qs = buildSearchString(today, null, today, 3, 'all', 'all', '', true)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: true })
+    expect(parsed).toEqual({ date: today, run: null, numDays: 3, filterBenchmark: 'all', filterStatus: 'all', filterText: '', clusterHealth: true, evalTime: false })
   })
 
   it('round-trips clusterHealth with other params', () => {
@@ -206,6 +216,6 @@ describe('round-trip: buildSearchString -> parseSearchParams', () => {
     const run = 'swebench/model/123'
     const qs = buildSearchString(date, run, today, 5, 'swebench', 'completed', 'gpt4', true)
     const parsed = parseSearchParams(qs, today)
-    expect(parsed).toEqual({ date, run, numDays: 5, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: true })
+    expect(parsed).toEqual({ date, run, numDays: 5, filterBenchmark: 'swebench', filterStatus: 'completed', filterText: 'gpt4', clusterHealth: true, evalTime: false })
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -612,6 +612,85 @@ export function getClusterHealthState(report: ClusterHealthReport, now: number =
   return 'healthy'
 }
 
+// ---------------------------------------------------------------------------
+// Eval Time Health — monitors how long active evals spend in each stage
+// ---------------------------------------------------------------------------
+
+export type EvalTimeState = 'healthy' | 'warning' | 'critical'
+
+/** Per-stage warning / critical thresholds (milliseconds). */
+export const EVAL_TIME_WARNING_MS = 10 * 60 * 60 * 1000  // 10 hours
+export const EVAL_TIME_CRITICAL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+export interface EvalTimeEntry {
+  slug: string
+  status: RunListItemStatus
+  elapsedMs: number
+  stageLabel: string
+}
+
+export interface EvalTimeReport {
+  entries: EvalTimeEntry[]           // only entries that exceed the warning threshold
+  totalActive: number                // total non-finished evals inspected
+  state: EvalTimeState
+}
+
+/** Human-readable label for the stage an eval is stuck in. */
+function stageLabelFor(status: RunListItemStatus): string {
+  switch (status) {
+    case 'building': return 'Building'
+    case 'running-infer': return 'Inference'
+    case 'running-eval': return 'Evaluation'
+    case 'pending': return 'Pending'
+    default: return status
+  }
+}
+
+/** Return the timestamp (ms) at which the current stage started, or null. */
+function stageStartMs(metadata: RunMetadata, status: RunListItemStatus): number | null {
+  switch (status) {
+    case 'building': return getTimestampMs(metadata.params)
+    case 'pending': return getTimestampMs(metadata.init) ?? getTimestampMs(metadata.params)
+    case 'running-infer': return getTimestampMs(metadata.runInferStart)
+    case 'running-eval': return getTimestampMs(metadata.evalInferStart) ?? getTimestampMs(metadata.runInferEnd)
+    default: return null
+  }
+}
+
+/** Build an EvalTimeReport from all known run metadata.
+ *  Only non-finished runs are inspected; only entries exceeding the warning
+ *  threshold appear in `entries`. */
+export function computeEvalTimeReport(
+  metadataMap: Record<string, RunMetadata>,
+  preStatuses: Record<string, RunListItemStatus>,
+  now: number = Date.now(),
+): EvalTimeReport {
+  const entries: EvalTimeEntry[] = []
+  let totalActive = 0
+
+  for (const [slug, metadata] of Object.entries(metadataMap)) {
+    const status = preStatuses[slug] ?? getStageStatus(metadata)
+    if (status === 'completed' || status === 'error' || status === 'cancelled') continue
+    totalActive++
+
+    const start = stageStartMs(metadata, status)
+    if (start === null) continue
+    const elapsed = now - start
+    if (elapsed >= EVAL_TIME_WARNING_MS) {
+      entries.push({ slug, status, elapsedMs: elapsed, stageLabel: stageLabelFor(status) })
+    }
+  }
+
+  // Sort longest-running first
+  entries.sort((a, b) => b.elapsedMs - a.elapsedMs)
+
+  let state: EvalTimeState = 'healthy'
+  if (entries.some(e => e.elapsedMs >= EVAL_TIME_CRITICAL_MS)) state = 'critical'
+  else if (entries.length > 0) state = 'warning'
+
+  return { entries, totalActive, state }
+}
+
 export function buildOriginalRunUrl(_currentUrl: string, originalRunSlug: string): string {
   // Extract the original timestamp from the slug (last part after the last /)
   const parts = originalRunSlug.split('/')

--- a/frontend/src/components/EvalTime/EvalTimeModal.tsx
+++ b/frontend/src/components/EvalTime/EvalTimeModal.tsx
@@ -1,0 +1,109 @@
+import { EVAL_TIME_CRITICAL_MS, formatDurationMs, parseRunSlug } from '../../api'
+import type { EvalTimeReport } from '../../api'
+import { Hint, Section, Stat, STATE_STYLES } from '../ClusterHealth/primitives'
+
+interface Props {
+  report: EvalTimeReport
+  onClose: () => void
+  onSelectRun?: (slug: string) => void
+}
+
+export default function EvalTimeModal({ report, onClose, onSelectRun }: Props) {
+  const styles = STATE_STYLES[report.state]
+  const criticalCount = report.entries.filter(e => e.elapsedMs >= EVAL_TIME_CRITICAL_MS).length
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-4 overflow-y-auto"
+      onClick={onClose}
+    >
+      <div
+        className="bg-oh-surface border border-oh-border rounded-lg max-w-2xl w-full mt-16 p-5 text-sm text-oh-text"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className={`w-2.5 h-2.5 rounded-full ${styles.dot}`} />
+            <h2 className="text-base font-semibold">Eval Time</h2>
+          </div>
+          <button onClick={onClose} className="text-oh-text-muted hover:text-oh-text" title="Close">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3 mb-4">
+          <Stat
+            label="Active evals"
+            value={String(report.totalActive)}
+            hint="Total number of evaluation runs currently in a non-finished state (pending, building, running inference, or running evaluation)."
+          />
+          <Stat
+            label="Slow evals"
+            value={String(report.entries.length)}
+            valueClass={report.entries.length > 0 ? 'text-oh-warning' : 'text-oh-text-muted'}
+            hint="Evaluations that have been in their current stage for more than 10 hours. These may be stuck or experiencing issues."
+          />
+          <Stat
+            label="Critical (>24h)"
+            value={String(criticalCount)}
+            valueClass={criticalCount > 0 ? 'text-oh-error' : 'text-oh-text-muted'}
+            hint="Evaluations stuck in a single stage for more than 24 hours. These are almost certainly broken and should be investigated or cancelled."
+          />
+        </div>
+
+        {report.entries.length === 0 && (
+          <div className="text-oh-text-muted text-center py-6">
+            All active evaluations are within normal time ranges.
+          </div>
+        )}
+
+        {report.entries.length > 0 && (
+          <Section title={`Slow evaluations (${report.entries.length})`}>
+            <div className="space-y-2">
+              {report.entries.map(entry => {
+                const parsed = parseRunSlug(entry.slug)
+                const isCritical = entry.elapsedMs >= EVAL_TIME_CRITICAL_MS
+                return (
+                  <div
+                    key={entry.slug}
+                    className={`bg-oh-bg border rounded px-3 py-2 ${isCritical ? 'border-oh-error/50' : 'border-oh-border'}`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        {onSelectRun ? (
+                          <button
+                            onClick={() => { onClose(); onSelectRun(entry.slug) }}
+                            className="text-oh-primary hover:underline text-left truncate block max-w-full font-mono text-xs"
+                            title={entry.slug}
+                          >
+                            {parsed.benchmark}/{parsed.model}
+                          </button>
+                        ) : (
+                          <span className="font-mono text-xs truncate block" title={entry.slug}>
+                            {parsed.benchmark}/{parsed.model}
+                          </span>
+                        )}
+                        <span className="text-[11px] text-oh-text-muted">{parsed.jobId}</span>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <div className={`text-sm font-medium ${isCritical ? 'text-oh-error' : 'text-oh-warning'}`}>
+                          {formatDurationMs(entry.elapsedMs)}
+                        </div>
+                        <div className="text-[11px] text-oh-text-muted flex items-center gap-1 justify-end">
+                          {entry.stageLabel}
+                          <Hint text={`This evaluation has been in the "${entry.stageLabel}" stage for ${formatDurationMs(entry.elapsedMs)}. Warning threshold is 10 hours, critical threshold is 24 hours.`} />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </Section>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/EvalTimeBadge.tsx
+++ b/frontend/src/components/EvalTimeBadge.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from 'react'
+import { computeEvalTimeReport } from '../api'
+import type { RunMetadata, RunListItem, RunListItemStatus, EvalTimeReport } from '../api'
+import { BadgePill, STATE_STYLES } from './ClusterHealth/primitives'
+import EvalTimeModal from './EvalTime/EvalTimeModal'
+
+interface Props {
+  runMetadataMap: Record<string, RunMetadata>
+  runs: RunListItem[]
+  isOpen?: boolean
+  onToggle?: (open: boolean) => void
+  onSelectRun?: (slug: string) => void
+}
+
+export default function EvalTimeBadge({ runMetadataMap, runs, isOpen, onToggle, onSelectRun }: Props) {
+  const report: EvalTimeReport = useMemo(() => {
+    // Build a preStatuses map from runs that already carry a status
+    const preStatuses: Record<string, RunListItemStatus> = {}
+    for (const run of runs) {
+      if (run.status) {
+        preStatuses[run.slug] = run.status
+      }
+    }
+    return computeEvalTimeReport(runMetadataMap, preStatuses)
+  }, [runMetadataMap, runs])
+
+  const open = isOpen ?? false
+
+  // Show pulsing placeholder only while the initial run list hasn't loaded yet.
+  // Once runs are available (even if runMetadataMap is empty because all runs
+  // had pre-parsed statuses), show the computed state.
+  if (runs.length === 0 && Object.keys(runMetadataMap).length === 0) {
+    return <BadgePill dotClass="bg-oh-text-muted" dotPulse label="Eval Time" />
+  }
+
+  const { state, entries } = report
+  const styles = STATE_STYLES[state]
+  const badgeLabel =
+    state === 'healthy' ? 'Eval Time: ok'
+    : state === 'warning' ? `Eval Time: slow (${entries.length})`
+    : `Eval Time: critical (${entries.length})`
+
+  return (
+    <>
+      <BadgePill
+        dotClass={styles.dot}
+        labelClass={styles.label}
+        label={badgeLabel}
+        title={state === 'healthy' ? 'All active evals within normal time' : `${entries.length} eval(s) exceeding time thresholds`}
+        onClick={() => onToggle?.(!open)}
+      />
+      {open && onToggle && (
+        <EvalTimeModal
+          report={report}
+          onClose={() => onToggle(false)}
+          onSelectRun={onSelectRun}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,6 @@
+import type { RunMetadata, RunListItem } from '../api'
 import ClusterHealthBadge from './ClusterHealthBadge'
+import EvalTimeBadge from './EvalTimeBadge'
 
 interface HeaderProps {
   date: string
@@ -11,9 +13,14 @@ interface HeaderProps {
   refreshNonce: number
   clusterHealthOpen: boolean
   onClusterHealthToggle: (open: boolean) => void
+  evalTimeOpen: boolean
+  onEvalTimeToggle: (open: boolean) => void
+  runMetadataMap: Record<string, RunMetadata>
+  runs: RunListItem[]
+  onSelectRun?: (slug: string) => void
 }
 
-export default function Header({ date, onDateChange, onRefresh, selectedRun, onBack, numDays, onNumDaysChange, refreshNonce, clusterHealthOpen, onClusterHealthToggle }: HeaderProps) {
+export default function Header({ date, onDateChange, onRefresh, selectedRun, onBack, numDays, onNumDaysChange, refreshNonce, clusterHealthOpen, onClusterHealthToggle, evalTimeOpen, onEvalTimeToggle, runMetadataMap, runs, onSelectRun }: HeaderProps) {
   const handlePrevDay = () => {
     const d = new Date(date + 'T00:00:00Z')
     d.setUTCDate(d.getUTCDate() - 1)
@@ -125,6 +132,7 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
           {/* Right: Cluster health + Refresh */}
           <div className="flex items-center gap-2">
             {!selectedRun && <ClusterHealthBadge refreshNonce={refreshNonce} isOpen={clusterHealthOpen} onToggle={onClusterHealthToggle} />}
+            {!selectedRun && <EvalTimeBadge runMetadataMap={runMetadataMap} runs={runs} isOpen={evalTimeOpen} onToggle={onEvalTimeToggle} onSelectRun={onSelectRun} />}
           <button
             onClick={onRefresh}
             className="p-2 rounded-lg text-oh-text-muted hover:text-oh-text hover:bg-oh-surface-hover transition-colors"


### PR DESCRIPTION
@juanmichelini I noticed that we often have stale evals that get forgotten. I’ve created a super simple badge to track evals that have been stuck in a specific state for more than X hours.

What do you think? We can use this to investigate and clear them out.

<img width="683" height="851" alt="Screenshot 2026-04-10 at 15 09 41" src="https://github.com/user-attachments/assets/6daac2d3-22f8-4eb3-a337-9dd42fb49d2d" />
