### PR TITLE
Add triggeredBy to slow evaluations in eval time modal

### DIFF
--- a/frontend/src/__tests__/eval-time.test.ts
+++ b/frontend/src/__tests__/eval-time.test.ts
@@ -451,6 +451,54 @@ describe('computeEvalTimeReport', () => {
   })
 
   // -------------------------------------------------------------------------
+  // triggeredBy is extracted from metadata
+  // -------------------------------------------------------------------------
+
+  describe('triggeredBy', () => {
+    it('extracts triggeredBy from params.triggered_by', () => {
+      const metadata = makeMetadata({
+        params: { timestamp: tsAgo(NOW, AT_WARNING), triggered_by: 'juanmichelini' },
+      })
+      const report = computeEvalTimeReport({ 'bench/model/1': metadata }, {}, NOW)
+      expect(report.entries[0].triggeredBy).toBe('juanmichelini')
+    })
+
+    it('extracts triggeredBy from init.actor as fallback', () => {
+      const metadata = makeMetadata({
+        params: { timestamp: tsAgo(NOW, AT_WARNING) },
+        init: { actor: 'alice' },
+      })
+      const report = computeEvalTimeReport({ 'bench/model/1': metadata }, {}, NOW)
+      expect(report.entries[0].triggeredBy).toBe('alice')
+    })
+
+    it('returns "—" when no trigger information is present', () => {
+      const metadata = makeMetadata({
+        params: { timestamp: tsAgo(NOW, AT_WARNING) },
+      })
+      const report = computeEvalTimeReport({ 'bench/model/1': metadata }, {}, NOW)
+      expect(report.entries[0].triggeredBy).toBe('—')
+    })
+
+    it('extracts different triggeredBy values for different entries', () => {
+      const metadata1 = makeMetadata({
+        params: { timestamp: tsAgo(NOW, AT_WARNING), triggered_by: 'user1' },
+      })
+      const metadata2 = makeMetadata({
+        params: { timestamp: tsAgo(NOW, AT_CRITICAL), triggered_by: 'user2' },
+      })
+      const report = computeEvalTimeReport(
+        { 'bench/model/1': metadata1, 'bench/model/2': metadata2 },
+        {},
+        NOW,
+      )
+      expect(report.entries).toHaveLength(2)
+      const triggeredBys = report.entries.map(e => e.triggeredBy).sort()
+      expect(triggeredBys).toEqual(['user1', 'user2'])
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // totalActive counts all non-finished runs regardless of threshold
   // -------------------------------------------------------------------------
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -627,6 +627,7 @@ export interface EvalTimeEntry {
   status: RunListItemStatus
   elapsedMs: number
   stageLabel: string
+  triggeredBy: string
 }
 
 export interface EvalTimeReport {
@@ -677,7 +678,7 @@ export function computeEvalTimeReport(
     if (start === null) continue
     const elapsed = now - start
     if (elapsed >= EVAL_TIME_WARNING_MS) {
-      entries.push({ slug, status, elapsedMs: elapsed, stageLabel: stageLabelFor(status) })
+      entries.push({ slug, status, elapsedMs: elapsed, stageLabel: stageLabelFor(status), triggeredBy: extractTriggeredBy(metadata) })
     }
   }
 

--- a/frontend/src/components/EvalTime/EvalTimeModal.tsx
+++ b/frontend/src/components/EvalTime/EvalTimeModal.tsx
@@ -86,6 +86,7 @@ export default function EvalTimeModal({ report, onClose, onSelectRun }: Props) {
                           </span>
                         )}
                         <span className="text-[11px] text-oh-text-muted">{parsed.jobId}</span>
+                        <span className="text-[11px] text-oh-text-muted">by {entry.triggeredBy}</span>
                       </div>
                       <div className="text-right shrink-0">
                         <div className={`text-sm font-medium ${isCritical ? 'text-oh-error' : 'text-oh-warning'}`}>


### PR DESCRIPTION
## Summary

This PR adds the name of the developer who triggered each slow evaluation to the Eval Time modal's slow evaluations section.

### Changes

1. **api.ts**: Added `triggeredBy` field to `EvalTimeEntry` interface and populated it using the existing `extractTriggeredBy()` function.

2. **EvalTimeModal.tsx**: Updated the slow evaluation entry display to show "by {triggeredBy}" below the job ID.

3. **eval-time.test.ts**: Added tests for the new `triggeredBy` field functionality.

### Testing

All 424 tests pass, including the 4 new tests for the `triggeredBy` field:
- Extracts triggeredBy from params.triggered_by
- Extracts triggeredBy from init.actor as fallback
- Returns "—" when no trigger information is present
- Extracts different triggeredBy values for different entries

---

Fixes #151