### PR TITLE
Use YYYY-MM-DD.jsonl instead of YYYY-MM-DD.txt for run list

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,9 +201,9 @@ export default function App() {
 
   const runSummaries = runs.map(runItem => {
     const parsed = parseRunSlug(runItem.slug)
-    // Use model from JSONL if available, otherwise parse from path
+    // Use model/runtime from JSONL if available, otherwise parse from path
     const model = runItem.model || parsed.model
-    return { slug: runItem.slug, status: runItem.status, triggeredBy: runItem.triggeredBy, triggerReason: runItem.triggerReason, benchmark: parsed.benchmark, jobId: parsed.jobId, model }
+    return { slug: runItem.slug, status: runItem.status, triggeredBy: runItem.triggeredBy, triggerReason: runItem.triggerReason, benchmark: parsed.benchmark, jobId: parsed.jobId, model, runtime: runItem.runtime }
   })
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ export function parseSearchParams(search: string, defaultDate: string): { date: 
   const date = params.get('date') || defaultDate
   const run = params.get('run') || null
   const numDaysParam = parseInt(params.get('days') || '3', 10)
-  const numDays = numDaysParam >= 1 && numDaysParam <= 30 ? numDaysParam : 3
+  const numDays = numDaysParam >= 1 && numDaysParam <= 90 ? numDaysParam : 3
   const filterBenchmark = params.get('benchmark') || 'all'
   const filterStatus = params.get('status') || 'all'
   const filterText = params.get('text') || ''

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,7 +201,9 @@ export default function App() {
 
   const runSummaries = runs.map(runItem => {
     const parsed = parseRunSlug(runItem.slug)
-    return { slug: runItem.slug, status: runItem.status, triggeredBy: runItem.triggeredBy, triggerReason: runItem.triggerReason, ...parsed }
+    // Use model from JSONL if available, otherwise parse from path
+    const model = runItem.model || parsed.model
+    return { slug: runItem.slug, status: runItem.status, triggeredBy: runItem.triggeredBy, triggerReason: runItem.triggerReason, benchmark: parsed.benchmark, jobId: parsed.jobId, model }
   })
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,45 +135,17 @@ export default function App() {
     }
   }, [date, numDays])
 
-  // Fetch metadata for runs that don't have pre-parsed status (for efficiency)
-  const loadAllMetadata = useCallback(async (runItems: RunListItem[]) => {
-    // Only fetch metadata for runs that don't already have a status
-    const runsNeedingMetadata = runItems.filter(r => !r.status)
-    if (runsNeedingMetadata.length === 0) return
-    
-    setLoadingMetadataList(true)
-    const batchSize = 10
-    for (let i = 0; i < runsNeedingMetadata.length; i += batchSize) {
-      const batch = runsNeedingMetadata.slice(i, i + batchSize)
-      const results = await Promise.all(
-        batch.map(async item => {
-          try {
-            const metadata = await fetchRunMetadata(item.slug)
-            return { slug: item.slug, metadata }
-          } catch {
-            return { slug: item.slug, metadata: null }
-          }
-        })
-      )
-      const batchMap: Record<string, RunMetadata> = {}
-      results.forEach(({ slug, metadata }) => {
-        if (metadata) batchMap[slug] = metadata
-      })
-      setRunMetadataMap(prev => ({ ...prev, ...batchMap }))
-    }
-    setLoadingMetadataList(false)
-  }, [])
-
   useEffect(() => {
     loadRuns()
   }, [loadRuns])
 
-  // When runs are loaded, fetch metadata for runs that need it
+  // When runs are loaded, no need to fetch metadata for list view anymore
+  // All data (status, triggeredBy, triggerReason) comes from JSONL
   useEffect(() => {
     if (runs.length > 0 && !selectedRun) {
-      loadAllMetadata(runs)
+      setLoadingMetadataList(false)
     }
-  }, [runs, selectedRun, loadAllMetadata])
+  }, [runs, selectedRun])
 
   // If we have a run from URL but haven't loaded its metadata yet, fetch it
   useEffect(() => {
@@ -229,7 +201,7 @@ export default function App() {
 
   const runSummaries = runs.map(runItem => {
     const parsed = parseRunSlug(runItem.slug)
-    return { slug: runItem.slug, status: runItem.status, ...parsed }
+    return { slug: runItem.slug, status: runItem.status, triggeredBy: runItem.triggeredBy, triggerReason: runItem.triggerReason, ...parsed }
   })
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ export function parseSearchParams(search: string, defaultDate: string): { date: 
   const date = params.get('date') || defaultDate
   const run = params.get('run') || null
   const numDaysParam = parseInt(params.get('days') || '3', 10)
-  const numDays = numDaysParam >= 1 && numDaysParam <= 7 ? numDaysParam : 3
+  const numDays = numDaysParam >= 1 && numDaysParam <= 30 ? numDaysParam : 3
   const filterBenchmark = params.get('benchmark') || 'all'
   const filterStatus = params.get('status') || 'all'
   const filterText = params.get('text') || ''

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,8 +14,8 @@ export function parseSearchParams(search: string, defaultDate: string): { date: 
   const params = new URLSearchParams(search)
   const date = params.get('date') || defaultDate
   const run = params.get('run') || null
-  const numDaysParam = parseInt(params.get('days') || '3', 10)
-  const numDays = numDaysParam >= 1 && numDaysParam <= 90 ? numDaysParam : 3
+  const numDaysParam = parseInt(params.get('days') || '15', 10)
+  const numDays = numDaysParam >= 1 && numDaysParam <= 90 ? numDaysParam : 15
   const filterBenchmark = params.get('benchmark') || 'all'
   const filterStatus = params.get('status') || 'all'
   const filterText = params.get('text') || ''

--- a/frontend/src/__tests__/RunListView.test.tsx
+++ b/frontend/src/__tests__/RunListView.test.tsx
@@ -11,19 +11,22 @@ describe('RunListView', () => {
         slug: 'swebench/qwen-2.5-coder/123',
         benchmark: 'swebench',
         model: 'qwen-2.5-coder',
-        jobId: '123'
+        jobId: '123',
+        triggeredBy: 'juanmichelini'
       },
       {
         slug: 'gaia/claude-sonnet/456',
         benchmark: 'gaia',
         model: 'claude-sonnet',
-        jobId: '456'
+        jobId: '456',
+        triggeredBy: 'admin'
       },
       {
         slug: 'swebench/gpt-4o/789',
         benchmark: 'swebench',
         model: 'gpt-4o',
-        jobId: '789'
+        jobId: '789',
+        triggeredBy: 'admin'
       }
     ],
     loading: false,
@@ -347,9 +350,9 @@ describe('RunListView', () => {
     it('shows per-author breakdown for active workers based on worker count', () => {
       const props = {
         runs: [
-          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1' },
-          { slug: 'swebench/run2/2', benchmark: 'swebench', model: 'run2', jobId: '2' },
-          { slug: 'swebench/run3/3', benchmark: 'swebench', model: 'run3', jobId: '3' }
+          { slug: 'swebench/run1/1', benchmark: 'swebench', model: 'run1', jobId: '1', triggeredBy: 'alice' },
+          { slug: 'swebench/run2/2', benchmark: 'swebench', model: 'run2', jobId: '2', triggeredBy: 'alice' },
+          { slug: 'swebench/run3/3', benchmark: 'swebench', model: 'run3', jobId: '3', triggeredBy: 'bob' }
         ],
         loading: false,
         error: null,

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -747,9 +747,9 @@ describe('fetchRunList', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`{"slug": "swebench/model1/123", "status": "pending"}
-{"slug": "swebench/model2/456", "status": "completed"}
-{"slug": "swebench/model3/789", "status": "error"}
+        text: () => Promise.resolve(`{"path": "swebench/model1/123", "status": "init"}
+{"path": "swebench/model2/456", "status": "completed"}
+{"path": "swebench/model3/789", "status": "error"}
 `),
         headers: new Headers(),
       } as Response)
@@ -758,7 +758,23 @@ describe('fetchRunList', () => {
     expect(result).toEqual([
       { slug: 'swebench/model3/789', status: 'error' },
       { slug: 'swebench/model2/456', status: 'completed' },
-      { slug: 'swebench/model1/123', status: 'pending' },
+      { slug: 'swebench/model1/123', status: 'init' },
+    ])
+  })
+
+  it('maps "cancel" status to "cancelled"', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(`{"path": "swebench/model/123", "status": "cancel"}
+`),
+        headers: new Headers(),
+      } as Response)
+    )
+    const result = await fetchRunList('2024-01-01')
+    expect(result).toEqual([
+      { slug: 'swebench/model/123', status: 'cancelled' },
     ])
   })
 
@@ -767,9 +783,9 @@ describe('fetchRunList', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`{"slug": "swebench/model1/123", "status": "completed"}
-{"slug": "swebench/model2/456"}
-{"slug": "swebench/model3/789", "status": "running-infer"}
+        text: () => Promise.resolve(`{"path": "swebench/model1/123", "status": "completed"}
+{"path": "swebench/model2/456"}
+{"path": "swebench/model3/789", "status": "running-infer"}
 `),
         headers: new Headers(),
       } as Response)
@@ -787,9 +803,9 @@ describe('fetchRunList', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`{"slug": "swebench/model1/123"}
+        text: () => Promise.resolve(`{"path": "swebench/model1/123"}
 
-{"slug": "swebench/model2/456", "status": "completed"}
+{"path": "swebench/model2/456", "status": "completed"}
 
 invalid json here
 
@@ -804,13 +820,13 @@ invalid json here
     ])
   })
 
-  it('filters out items with empty slug', async () => {
+  it('filters out items with empty path', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`{"slug": "", "status": "completed"}
-{"slug": "swebench/model2/456", "status": "error"}
+        text: () => Promise.resolve(`{"path": "", "status": "completed"}
+{"path": "swebench/model2/456", "status": "error"}
 `),
         headers: new Headers(),
       } as Response)

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -747,8 +747,8 @@ describe('fetchRunList', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`{"path": "swebench/model1/123", "status": "completed"}
-{"path": "swebench/model2/456", "status": "error"}
+        text: () => Promise.resolve(`{"path": "swebench/model1/123", "status": "completed", "triggered_by": "user1", "trigger_reason": "PR #123"}
+{"path": "swebench/model2/456", "status": "error", "triggered_by": "user2", "trigger_reason": "scheduled"}
 {"path": "swebench/model3/789", "status": "running-infer"}
 `),
         headers: new Headers(),
@@ -757,8 +757,8 @@ describe('fetchRunList', () => {
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
       { slug: 'swebench/model3/789', status: 'running-infer' },
-      { slug: 'swebench/model2/456', status: 'error' },
-      { slug: 'swebench/model1/123', status: 'completed' },
+      { slug: 'swebench/model2/456', status: 'error', triggeredBy: 'user2', triggerReason: 'scheduled' },
+      { slug: 'swebench/model1/123', status: 'completed', triggeredBy: 'user1', triggerReason: 'PR #123' },
     ])
   })
 

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, getActiveWorkersForInstance, getPartialArchiveUrl, extractBenchmarkModelFromPartialArchiveUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl, parseRunListLine, fetchRunList, getClusterHealthState } from '../api'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, getActiveWorkersForInstance, getPartialArchiveUrl, extractBenchmarkModelFromPartialArchiveUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl, fetchRunList, getClusterHealthState } from '../api'
 import type { RunMetadata, ClusterHealthReport } from '../api'
 
 function makeReport(overrides: Partial<ClusterHealthReport> = {}): ClusterHealthReport {
@@ -709,96 +709,6 @@ describe('buildOriginalRunUrl', () => {
   })
 })
 
-describe('parseRunListLine', () => {
-  it('parses a simple slug without status', () => {
-    const result = parseRunListLine('swebench/litellm_proxy-claude-sonnet/123')
-    expect(result).toEqual({ slug: 'swebench/litellm_proxy-claude-sonnet/123' })
-  })
-
-  it('parses slug with completed status', () => {
-    const result = parseRunListLine('swebench/litellm_proxy-claude-sonnet-4-5/24051073329/ completed')
-    expect(result).toEqual({ slug: 'swebench/litellm_proxy-claude-sonnet-4-5/24051073329/', status: 'completed' })
-  })
-
-  it('parses slug with error status', () => {
-    const result = parseRunListLine('swebench/model/123 error')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'error' })
-  })
-
-  it('parses slug with pending status', () => {
-    const result = parseRunListLine('swebench/model/123 pending')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'pending' })
-  })
-
-  it('parses slug with building status', () => {
-    const result = parseRunListLine('swebench/model/123 building')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'building' })
-  })
-
-  it('parses slug with running-infer status', () => {
-    const result = parseRunListLine('swebench/model/123 running-infer')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'running-infer' })
-  })
-
-  it('parses slug with running-eval status', () => {
-    const result = parseRunListLine('swebench/model/123 running-eval')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'running-eval' })
-  })
-
-  it('parses slug with cancelled status', () => {
-    const result = parseRunListLine('swebench/model/123 cancelled')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'cancelled' })
-  })
-
-  it('ignores non-valid status values', () => {
-    const result = parseRunListLine('swebench/model/123 some_random_text')
-    expect(result).toEqual({ slug: 'swebench/model/123' })
-  })
-
-  it('ignores invalid status that looks like a benchmark name', () => {
-    const result = parseRunListLine('swebench/model/123 swebench')
-    expect(result).toEqual({ slug: 'swebench/model/123' })
-  })
-
-  it('handles empty line', () => {
-    const result = parseRunListLine('')
-    expect(result).toEqual({ slug: '' })
-  })
-
-  it('handles whitespace-only line', () => {
-    const result = parseRunListLine('   ')
-    expect(result).toEqual({ slug: '' })
-  })
-
-  it('handles slug with trailing whitespace', () => {
-    const result = parseRunListLine('swebench/model/123   ')
-    expect(result).toEqual({ slug: 'swebench/model/123' })
-  })
-
-  it('handles case-insensitive status', () => {
-    const result = parseRunListLine('swebench/model/123 COMPLETED')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'completed' })
-  })
-
-  it('handles mixed case status', () => {
-    const result = parseRunListLine('swebench/model/123 Running-Infer')
-    expect(result).toEqual({ slug: 'swebench/model/123', status: 'running-infer' })
-  })
-
-  it('handles slug with spaces in model name - returns slug only without status', () => {
-    // When there are more than 2 tokens, we can't determine where slug ends
-    // so we return slug only (status is not parsed)
-    const result = parseRunListLine('swebench/litellm proxy model/123 completed')
-    expect(result).toEqual({ slug: 'swebench/litellm' })
-  })
-
-  it('only considers second token as status if valid', () => {
-    // The model name contains "error" which shouldn't be treated as status
-    const result = parseRunListLine('swebench/error-handler-model/123')
-    expect(result).toEqual({ slug: 'swebench/error-handler-model/123' })
-  })
-})
-
 describe('fetchRunList', () => {
   beforeEach(() => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
@@ -832,15 +742,14 @@ describe('fetchRunList', () => {
     await expect(fetchRunList('2024-01-01')).rejects.toThrow('Failed to fetch run list: 500')
   })
 
-  it('parses lines correctly from response', async () => {
+  it('parses JSONL lines correctly', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`
-swebench/model1/123 pending
-swebench/model2/456 completed
-swebench/model3/789 error
+        text: () => Promise.resolve(`{"slug": "swebench/model1/123", "status": "pending"}
+{"slug": "swebench/model2/456", "status": "completed"}
+{"slug": "swebench/model3/789", "status": "error"}
 `),
         headers: new Headers(),
       } as Response)
@@ -853,15 +762,14 @@ swebench/model3/789 error
     ])
   })
 
-  it('handles mixed lines with and without status', async () => {
+  it('handles items with and without status', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`
-swebench/model1/123 completed
-swebench/model2/456
-swebench/model3/789 running-infer
+        text: () => Promise.resolve(`{"slug": "swebench/model1/123", "status": "completed"}
+{"slug": "swebench/model2/456"}
+{"slug": "swebench/model3/789", "status": "running-infer"}
 `),
         headers: new Headers(),
       } as Response)
@@ -874,15 +782,16 @@ swebench/model3/789 running-infer
     ])
   })
 
-  it('filters out empty lines', async () => {
+  it('filters out empty lines and invalid JSON', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`
-swebench/model1/123
+        text: () => Promise.resolve(`{"slug": "swebench/model1/123"}
 
-swebench/model2/456 completed
+{"slug": "swebench/model2/456", "status": "completed"}
+
+invalid json here
 
 `),
         headers: new Headers(),
@@ -892,6 +801,23 @@ swebench/model2/456 completed
     expect(result).toEqual([
       { slug: 'swebench/model2/456', status: 'completed' },
       { slug: 'swebench/model1/123' },
+    ])
+  })
+
+  it('filters out items with empty slug', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(`{"slug": "", "status": "completed"}
+{"slug": "swebench/model2/456", "status": "error"}
+`),
+        headers: new Headers(),
+      } as Response)
+    )
+    const result = await fetchRunList('2024-01-01')
+    expect(result).toEqual([
+      { slug: 'swebench/model2/456', status: 'error' },
     ])
   })
 })

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -756,9 +756,9 @@ describe('fetchRunList', () => {
     )
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
-      { slug: 'swebench/model3/789', status: 'running-infer' },
-      { slug: 'swebench/model2/456', status: 'error', triggeredBy: 'user2', triggerReason: 'scheduled' },
-      { slug: 'swebench/model1/123', status: 'completed', triggeredBy: 'user1', triggerReason: 'PR #123' },
+      { slug: 'swebench/model3/789', status: 'running-infer', model: 'model3' },
+      { slug: 'swebench/model2/456', status: 'error', triggeredBy: 'user2', triggerReason: 'scheduled', model: 'model2' },
+      { slug: 'swebench/model1/123', status: 'completed', triggeredBy: 'user1', triggerReason: 'PR #123', model: 'model1' },
     ])
   })
 
@@ -774,7 +774,7 @@ describe('fetchRunList', () => {
     )
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
-      { slug: 'swebench/model/123' },
+      { slug: 'swebench/model/123', model: 'model' },
     ])
   })
 
@@ -790,7 +790,7 @@ describe('fetchRunList', () => {
     )
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
-      { slug: 'swebench/model/123', status: 'cancelled' },
+      { slug: 'swebench/model/123', status: 'cancelled', model: 'model' },
     ])
   })
 
@@ -808,9 +808,9 @@ describe('fetchRunList', () => {
     )
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
-      { slug: 'swebench/model3/789', status: 'running-infer' },
-      { slug: 'swebench/model2/456' },
-      { slug: 'swebench/model1/123', status: 'completed' },
+      { slug: 'swebench/model3/789', status: 'running-infer', model: 'model3' },
+      { slug: 'swebench/model2/456', model: 'model2' },
+      { slug: 'swebench/model1/123', status: 'completed', model: 'model1' },
     ])
   })
 
@@ -831,8 +831,8 @@ invalid json here
     )
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
-      { slug: 'swebench/model2/456', status: 'completed' },
-      { slug: 'swebench/model1/123' },
+      { slug: 'swebench/model2/456', status: 'completed', model: 'model2' },
+      { slug: 'swebench/model1/123', model: 'model1' },
     ])
   })
 
@@ -849,7 +849,7 @@ invalid json here
     )
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
-      { slug: 'swebench/model2/456', status: 'error' },
+      { slug: 'swebench/model2/456', status: 'error', model: 'model2' },
     ])
   })
 })

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -747,18 +747,34 @@ describe('fetchRunList', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve(`{"path": "swebench/model1/123", "status": "init"}
-{"path": "swebench/model2/456", "status": "completed"}
-{"path": "swebench/model3/789", "status": "error"}
+        text: () => Promise.resolve(`{"path": "swebench/model1/123", "status": "completed"}
+{"path": "swebench/model2/456", "status": "error"}
+{"path": "swebench/model3/789", "status": "running-infer"}
 `),
         headers: new Headers(),
       } as Response)
     )
     const result = await fetchRunList('2024-01-01')
     expect(result).toEqual([
-      { slug: 'swebench/model3/789', status: 'error' },
-      { slug: 'swebench/model2/456', status: 'completed' },
-      { slug: 'swebench/model1/123', status: 'init' },
+      { slug: 'swebench/model3/789', status: 'running-infer' },
+      { slug: 'swebench/model2/456', status: 'error' },
+      { slug: 'swebench/model1/123', status: 'completed' },
+    ])
+  })
+
+  it('maps unknown status to undefined', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(`{"path": "swebench/model/123", "status": "init"}
+`),
+        headers: new Headers(),
+      } as Response)
+    )
+    const result = await fetchRunList('2024-01-01')
+    expect(result).toEqual([
+      { slug: 'swebench/model/123' },
     ])
   })
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,7 @@ export interface RunListItem {
   status?: RunListItemStatus
   triggeredBy?: string
   triggerReason?: string
+  model?: string
 }
 
 const VALID_STATUSES = new Set([
@@ -39,6 +40,9 @@ interface JsonlRunItem {
   trigger_reason?: string
   github_run_id?: string
   benchmark?: string
+  model_display_name?: string
+  model_name?: string
+  model_id?: string
 }
 
 export async function fetchRunList(date: string): Promise<RunListItem[]> {
@@ -62,11 +66,20 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
         slug = `${benchmark}/nocache/${item.github_run_id}`
       }
       if (slug) {
+        // Extract model from path for entries with path, otherwise use model_display_name from JSONL
+        let model: string | undefined
+        if (item.path) {
+          const parsed = parseRunSlug(item.path)
+          model = parsed.model
+        } else if (item.model_display_name) {
+          model = item.model_display_name
+        }
         items.push({
           slug,
           status: mapStatus(item.status),
           triggeredBy: item.triggered_by || undefined,
           triggerReason: item.trigger_reason || undefined,
+          model,
         })
       }
     } catch {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,39 +8,9 @@ export interface RunListItem {
   status?: RunListItemStatus
 }
 
-const VALID_STATUSES: readonly string[] = [
-  'pending',
-  'building',
-  'running-infer',
-  'running-eval',
-  'completed',
-  'error',
-  'cancelled',
-]
-
-/** Parse a line from the run list file.
- *  Format: "path/to/run" or "path/to/run status"
- *  Returns an object with slug and optional status if found.
- */
-export function parseRunListLine(line: string): RunListItem {
-  const trimmed = line.trim()
-  if (!trimmed) return { slug: '' }
-
-  // Split on whitespace to find optional status
-  const parts = trimmed.split(/\s+/)
-  const slug = parts[0]
-  const potentialStatus = parts[1]?.toLowerCase()
-
-  if (potentialStatus && VALID_STATUSES.includes(potentialStatus)) {
-    return { slug, status: potentialStatus as RunListItemStatus }
-  }
-
-  return { slug }
-}
-
 export async function fetchRunList(date: string): Promise<RunListItem[]> {
   const cacheBust = Math.floor(Date.now() / 1000)
-  const res = await fetch(`${BASE_URL}/metadata/${date}.txt?${cacheBust}`)
+  const res = await fetch(`${BASE_URL}/metadata/${date}.jsonl?${cacheBust}`)
   if (!res.ok) {
     if (res.status === 404) return []
     throw new Error(`Failed to fetch run list: ${res.status}`)
@@ -48,8 +18,15 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
   const text = await res.text()
   return text
     .split('\n')
-    .map(line => parseRunListLine(line))
-    .filter(item => item.slug.length > 0)
+    .filter(line => line.trim())
+    .map(line => {
+      try {
+        return JSON.parse(line) as RunListItem
+      } catch {
+        return null
+      }
+    })
+    .filter((item): item is RunListItem => item !== null && item.slug.length > 0)
     .reverse()
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -27,7 +27,10 @@ const VALID_STATUSES = new Set([
  *  Only returns a status if it's a known status value. */
 function mapStatus(status: string | undefined): RunListItemStatus | undefined {
   if (!status) return undefined
+  // Map JSONL status values to our canonical status
   if (status === 'cancel') return 'cancelled'
+  if (status === 'inferring') return 'running-infer'
+  if (status === 'evaluating') return 'running-eval'
   if (VALID_STATUSES.has(status)) return status as RunListItemStatus
   return undefined
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,21 @@ export interface RunListItem {
   status?: RunListItemStatus
 }
 
+/** Map status from JSONL format to RunListItemStatus.
+ *  JSONL uses "cancel" but we use "cancelled". */
+function mapStatus(status: string | undefined): RunListItemStatus | undefined {
+  if (!status) return undefined
+  if (status === 'cancel') return 'cancelled'
+  return status as RunListItemStatus
+}
+
+/** Parse a single line from the JSONL run list file.
+ *  The JSONL file has "path" field for slug and "status" for the status. */
+interface JsonlRunItem {
+  path: string
+  status?: string
+}
+
 export async function fetchRunList(date: string): Promise<RunListItem[]> {
   const cacheBust = Math.floor(Date.now() / 1000)
   const res = await fetch(`${BASE_URL}/metadata/${date}.jsonl?${cacheBust}`)
@@ -16,18 +31,23 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
     throw new Error(`Failed to fetch run list: ${res.status}`)
   }
   const text = await res.text()
-  return text
-    .split('\n')
-    .filter(line => line.trim())
-    .map(line => {
-      try {
-        return JSON.parse(line) as RunListItem
-      } catch {
-        return null
+  const items: RunListItem[] = []
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      const item = JSON.parse(trimmed) as JsonlRunItem
+      if (item.path) {
+        items.push({
+          slug: item.path,
+          status: mapStatus(item.status),
+        })
       }
-    })
-    .filter((item): item is RunListItem => item !== null && item.slug.length > 0)
-    .reverse()
+    } catch {
+      // Skip invalid JSON lines
+    }
+  }
+  return items.reverse()
 }
 
 export function getDateNDaysAgo(baseDate: string, n: number): string {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -30,6 +30,7 @@ function mapStatus(status: string | undefined): RunListItemStatus | undefined {
   if (status === 'cancel') return 'cancelled'
   if (status === 'inferring') return 'running-infer'
   if (status === 'evaluating') return 'running-eval'
+  if (status === 'init') return 'building'
   if (VALID_STATUSES.has(status)) return status as RunListItemStatus
   return undefined
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -30,12 +30,15 @@ function mapStatus(status: string | undefined): RunListItemStatus | undefined {
 }
 
 /** Parse a single line from the JSONL run list file.
- *  The JSONL file has "path" field for slug and "status" for the status. */
+ *  The JSONL file has "path" field for slug and "status" for the status.
+ *  Some entries may not have "path" - those use "github_run_id" instead. */
 interface JsonlRunItem {
-  path: string
+  path?: string
   status?: string
   triggered_by?: string
   trigger_reason?: string
+  github_run_id?: string
+  benchmark?: string
 }
 
 export async function fetchRunList(date: string): Promise<RunListItem[]> {
@@ -52,9 +55,15 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
     if (!trimmed) continue
     try {
       const item = JSON.parse(trimmed) as JsonlRunItem
-      if (item.path) {
+      let slug = item.path
+      // Some entries may not have path; construct from github_run_id if available
+      if (!slug && item.github_run_id) {
+        const benchmark = item.benchmark || 'unknown'
+        slug = `${benchmark}/nocache/${item.github_run_id}`
+      }
+      if (slug) {
         items.push({
-          slug: item.path,
+          slug,
           status: mapStatus(item.status),
           triggeredBy: item.triggered_by || undefined,
           triggerReason: item.trigger_reason || undefined,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -67,10 +67,11 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
     try {
       const item = JSON.parse(trimmed) as JsonlRunItem
       let slug = item.path
-      // Some entries may not have path; construct from github_run_id if available
+      // Some entries may not have path; construct from model_name and github_run_id
       if (!slug && item.github_run_id) {
         const benchmark = item.benchmark || 'unknown'
-        slug = `${benchmark}/nocache/${item.github_run_id}`
+        const modelName = item.model_name ? item.model_name.replace(/\//g, '-') : 'unknown'
+        slug = `${benchmark}/${modelName}/${item.github_run_id}/`
       }
       if (slug) {
         // Extract model from path for entries with path, otherwise use model_id from JSONL

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -70,7 +70,8 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
       // Some entries may not have path; construct from model_name and github_run_id
       if (!slug && item.github_run_id) {
         const benchmark = item.benchmark || 'unknown'
-        const modelName = item.model_name ? item.model_name.replace(/\//g, '-') : 'unknown'
+        // Replace / and . with - in model_name to match folder structure
+        const modelName = item.model_name ? item.model_name.replace(/[\/\.]/g, '-') : 'unknown'
         slug = `${benchmark}/${modelName}/${item.github_run_id}/`
       }
       if (slug) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
 const BASE_URL = '/api'
 const RESULTS_BASE_URL = 'https://results.eval.all-hands.dev'
 
-export type RunListItemStatus = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
+export type RunListItemStatus = 'pending' | 'building' | 'init' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
 
 export interface RunListItem {
   slug: string
@@ -15,6 +15,7 @@ export interface RunListItem {
 const VALID_STATUSES = new Set([
   'pending',
   'building',
+  'init',
   'running-infer',
   'running-eval',
   'completed',

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -66,13 +66,13 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
         slug = `${benchmark}/nocache/${item.github_run_id}`
       }
       if (slug) {
-        // Extract model from path for entries with path, otherwise use model_display_name from JSONL
+        // Extract model from path for entries with path, otherwise use model_id from JSONL
         let model: string | undefined
         if (item.path) {
           const parsed = parseRunSlug(item.path)
           model = parsed.model
-        } else if (item.model_display_name) {
-          model = item.model_display_name
+        } else if (item.model_id) {
+          model = item.model_id
         }
         items.push({
           slug,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -6,6 +6,8 @@ export type RunListItemStatus = 'pending' | 'building' | 'running-infer' | 'runn
 export interface RunListItem {
   slug: string
   status?: RunListItemStatus
+  triggeredBy?: string
+  triggerReason?: string
 }
 
 const VALID_STATUSES = new Set([
@@ -32,6 +34,8 @@ function mapStatus(status: string | undefined): RunListItemStatus | undefined {
 interface JsonlRunItem {
   path: string
   status?: string
+  triggered_by?: string
+  trigger_reason?: string
 }
 
 export async function fetchRunList(date: string): Promise<RunListItem[]> {
@@ -52,6 +56,8 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
         items.push({
           slug: item.path,
           status: mapStatus(item.status),
+          triggeredBy: item.triggered_by || undefined,
+          triggerReason: item.trigger_reason || undefined,
         })
       }
     } catch {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,6 +9,7 @@ export interface RunListItem {
   triggeredBy?: string
   triggerReason?: string
   model?: string
+  runtime?: string
 }
 
 const VALID_STATUSES = new Set([
@@ -43,6 +44,8 @@ interface JsonlRunItem {
   model_display_name?: string
   model_name?: string
   model_id?: string
+  init_timestamp?: string
+  end_timestamp?: string
 }
 
 export async function fetchRunList(date: string): Promise<RunListItem[]> {
@@ -74,12 +77,20 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
         } else if (item.model_id) {
           model = item.model_id
         }
+        // Calculate runtime from JSONL timestamps
+        let runtime: string | undefined
+        if (item.init_timestamp) {
+          const start = new Date(item.init_timestamp).getTime()
+          const end = item.end_timestamp ? new Date(item.end_timestamp).getTime() : Date.now()
+          runtime = formatDurationMs(end - start)
+        }
         items.push({
           slug,
           status: mapStatus(item.status),
           triggeredBy: item.triggered_by || undefined,
           triggerReason: item.trigger_reason || undefined,
           model,
+          runtime,
         })
       }
     } catch {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,12 +8,23 @@ export interface RunListItem {
   status?: RunListItemStatus
 }
 
+const VALID_STATUSES = new Set([
+  'pending',
+  'building',
+  'running-infer',
+  'running-eval',
+  'completed',
+  'error',
+  'cancelled',
+])
+
 /** Map status from JSONL format to RunListItemStatus.
- *  JSONL uses "cancel" but we use "cancelled". */
+ *  Only returns a status if it's a known status value. */
 function mapStatus(status: string | undefined): RunListItemStatus | undefined {
   if (!status) return undefined
   if (status === 'cancel') return 'cancelled'
-  return status as RunListItemStatus
+  if (VALID_STATUSES.has(status)) return status as RunListItemStatus
+  return undefined
 }
 
 /** Parse a single line from the JSONL run list file.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
 const BASE_URL = '/api'
 const RESULTS_BASE_URL = 'https://results.eval.all-hands.dev'
 
-export type RunListItemStatus = 'pending' | 'building' | 'init' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
+export type RunListItemStatus = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
 
 export interface RunListItem {
   slug: string
@@ -15,7 +15,6 @@ export interface RunListItem {
 const VALID_STATUSES = new Set([
   'pending',
   'building',
-  'init',
   'running-infer',
   'running-eval',
   'completed',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -120,7 +120,7 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
                 className="bg-oh-bg border border-oh-border rounded-lg px-3 py-1.5 text-sm text-oh-text focus:outline-none focus:border-oh-primary transition-colors ml-2"
                 title="Number of days to display"
               >
-                {[1, 2, 3, 4, 5, 6, 7].map(n => (
+                {[1, 2, 3, 4, 5, 6, 7, 15, 30].map(n => (
                   <option key={n} value={n}>
                     {n} {n === 1 ? 'day' : 'days'}
                   </option>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -120,7 +120,7 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
                 className="bg-oh-bg border border-oh-border rounded-lg px-3 py-1.5 text-sm text-oh-text focus:outline-none focus:border-oh-primary transition-colors ml-2"
                 title="Number of days to display"
               >
-                {[1, 2, 3, 4, 5, 6, 7, 15, 30].map(n => (
+                {[1, 2, 3, 4, 5, 6, 7, 15, 30, 60, 90].map(n => (
                   <option key={n} value={n}>
                     {n} {n === 1 ? 'day' : 'days'}
                   </option>

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -31,7 +31,7 @@ interface RunListViewProps {
   showDetail: boolean
 }
 
-type StatusType = 'pending' | 'building' | 'init' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
+type StatusType = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
 
 const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?: string }> = {
   pending: {
@@ -39,12 +39,7 @@ const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?
     className: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
   },
   building: {
-    label: 'Building Images',
-    className: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
-    dot: 'bg-violet-400 animate-pulse',
-  },
-  init: {
-    label: 'Init',
+    label: 'Building',
     className: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
     dot: 'bg-violet-400 animate-pulse',
   },
@@ -183,7 +178,7 @@ export default function RunListView({
       if (filterStatus !== 'all') {
         if (filterStatus === 'active') {
           // Active status: show all non-terminal statuses
-          const activeStatuses: StatusType[] = ['pending', 'building', 'init', 'running-infer', 'running-eval']
+          const activeStatuses: StatusType[] = ['pending', 'building', 'running-infer', 'running-eval']
           if (!activeStatuses.includes(run.status)) return false
         } else if (run.status !== filterStatus) {
           return false

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import type { RunMetadata, DayRunGroup, RunListItemStatus, RunListItem } from '../api'
-import { getStageStatus, getRuntime, isFinished, extractTriggeredBy, extractTriggerReason, getActiveWorkersForInstance } from '../api'
+import type { RunMetadata, DayRunGroup, RunListItemStatus } from '../api'
+import { getStageStatus, getRuntime, isFinished, getActiveWorkersForInstance } from '../api'
 import ExportPathsModal from './ExportPathsModal'
 
 interface RunInfo {
@@ -9,6 +9,8 @@ interface RunInfo {
   model: string
   jobId: string
   status?: RunListItemStatus
+  triggeredBy?: string
+  triggerReason?: string
 }
 
 interface RunListViewProps {
@@ -148,18 +150,18 @@ export default function RunListView({
     return () => clearInterval(interval)
   }, [hasNonFinished])
 
-  // Compute statuses, runtimes, and triggered-by
-  // Use pre-parsed values from list file if available, otherwise derive from metadata
+  // Compute statuses and runtimes
+  // Status comes from JSONL (pre-parsed), runtime needs metadata for active runs
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
       const metadata = runMetadataMap[run.slug]
-      // Use pre-parsed status if available, otherwise derive from metadata
+      // Use pre-parsed status from JSONL, only derive from metadata if needed
       const status: StatusType = run.status || (metadata ? getStageStatus(metadata) : 'pending')
       const runtime: string | null = metadata ? getRuntime(metadata, now) : null
       const runFinished = metadata ? isFinished(metadata) : true
-      // triggeredBy and triggerReason come from run props (passed from App.tsx which gets them from fetchRunList)
-      const triggeredBy = (run as RunListItem).triggeredBy || (metadata ? extractTriggeredBy(metadata) : undefined)
-      const triggerReason = (run as RunListItem).triggerReason || (metadata ? extractTriggerReason(metadata) : undefined)
+      // triggeredBy and triggerReason come directly from JSONL (via RunListItem)
+      const triggeredBy = run.triggeredBy
+      const triggerReason = run.triggerReason
       return { ...run, status, runtime, runFinished, triggeredBy, triggerReason }
     })
   }, [runs, runMetadataMap, now])

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import type { RunMetadata, DayRunGroup, RunListItemStatus } from '../api'
+import type { RunMetadata, DayRunGroup, RunListItemStatus, RunListItem } from '../api'
 import { getStageStatus, getRuntime, isFinished, extractTriggeredBy, extractTriggerReason, getActiveWorkersForInstance } from '../api'
 import ExportPathsModal from './ExportPathsModal'
 
@@ -149,7 +149,7 @@ export default function RunListView({
   }, [hasNonFinished])
 
   // Compute statuses, runtimes, and triggered-by
-  // Use pre-parsed status from list file if available, otherwise derive from metadata
+  // Use pre-parsed values from list file if available, otherwise derive from metadata
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
       const metadata = runMetadataMap[run.slug]
@@ -157,8 +157,9 @@ export default function RunListView({
       const status: StatusType = run.status || (metadata ? getStageStatus(metadata) : 'pending')
       const runtime: string | null = metadata ? getRuntime(metadata, now) : null
       const runFinished = metadata ? isFinished(metadata) : true
-      const triggeredBy = extractTriggeredBy(metadata)
-      const triggerReason = extractTriggerReason(metadata)
+      // triggeredBy and triggerReason come from run props (passed from App.tsx which gets them from fetchRunList)
+      const triggeredBy = (run as RunListItem).triggeredBy || (metadata ? extractTriggeredBy(metadata) : undefined)
+      const triggerReason = (run as RunListItem).triggerReason || (metadata ? extractTriggerReason(metadata) : undefined)
       return { ...run, status, runtime, runFinished, triggeredBy, triggerReason }
     })
   }, [runs, runMetadataMap, now])

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -44,17 +44,17 @@ const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?
     dot: 'bg-violet-400 animate-pulse',
   },
   init: {
-    label: 'Initializing',
+    label: 'Init',
     className: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
     dot: 'bg-violet-400 animate-pulse',
   },
   'running-infer': {
-    label: 'Running Inference',
+    label: 'Inference',
     className: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
     dot: 'bg-blue-400 animate-pulse',
   },
   'running-eval': {
-    label: 'Running Eval',
+    label: 'Eval',
     className: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
     dot: 'bg-amber-400 animate-pulse',
   },
@@ -182,8 +182,8 @@ export default function RunListView({
       if (filterBenchmark !== 'all' && run.benchmark !== filterBenchmark) return false
       if (filterStatus !== 'all') {
         if (filterStatus === 'active') {
-          // Active status: show all non-terminal statuses (pending, building, running-infer, running-eval)
-          const activeStatuses: StatusType[] = ['pending', 'building', 'running-infer', 'running-eval']
+          // Active status: show all non-terminal statuses
+          const activeStatuses: StatusType[] = ['pending', 'building', 'init', 'running-infer', 'running-eval']
           if (!activeStatuses.includes(run.status)) return false
         } else if (run.status !== filterStatus) {
           return false

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -31,7 +31,7 @@ interface RunListViewProps {
   showDetail: boolean
 }
 
-type StatusType = 'pending' | 'building' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
+type StatusType = 'pending' | 'building' | 'init' | 'running-infer' | 'running-eval' | 'completed' | 'error' | 'cancelled'
 
 const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?: string }> = {
   pending: {
@@ -40,6 +40,11 @@ const STATUS_CONFIG: Record<StatusType, { label: string; className: string; dot?
   },
   building: {
     label: 'Building Images',
+    className: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
+    dot: 'bg-violet-400 animate-pulse',
+  },
+  init: {
+    label: 'Initializing',
     className: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
     dot: 'bg-violet-400 animate-pulse',
   },

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -361,6 +361,14 @@ export default function RunListView({
           </svg>
           Export paths
         </button>
+        <a
+          href="https://eval-monitor-git-legacy-txt-list-openhands.vercel.app/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-oh-text-muted hover:text-oh-text transition-colors"
+        >
+          Run missing, try legacy Eval Monitor
+        </a>
       </div>
 
       {/* Export Paths Modal */}

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -11,6 +11,7 @@ interface RunInfo {
   status?: RunListItemStatus
   triggeredBy?: string
   triggerReason?: string
+  runtime?: string
 }
 
 interface RunListViewProps {
@@ -151,14 +152,15 @@ export default function RunListView({
   }, [hasNonFinished])
 
   // Compute statuses and runtimes
-  // Status comes from JSONL (pre-parsed), runtime needs metadata for active runs
+  // Status and runtime come from JSONL (pre-parsed), metadata only needed for additional details
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
       const metadata = runMetadataMap[run.slug]
       // Use pre-parsed status from JSONL, only derive from metadata if needed
       const status: StatusType = run.status || (metadata ? getStageStatus(metadata) : 'pending')
-      const runtime: string | null = metadata ? getRuntime(metadata, now) : null
-      const runFinished = metadata ? isFinished(metadata) : true
+      // Use pre-parsed runtime from JSONL if available, otherwise calculate from metadata
+      const runtime: string | null = run.runtime || (metadata ? getRuntime(metadata, now) : null)
+      const runFinished = metadata ? isFinished(metadata) : (run.status === 'completed' || run.status === 'error' || run.status === 'cancelled')
       // triggeredBy and triggerReason come directly from JSONL (via RunListItem)
       const triggeredBy = run.triggeredBy
       const triggerReason = run.triggerReason

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -367,7 +367,7 @@ export default function RunListView({
           rel="noopener noreferrer"
           className="text-xs text-oh-text-muted hover:text-oh-text transition-colors"
         >
-          Run missing, try legacy Eval Monitor
+          Run missing? Fall back to legacy Eval Monitor
         </a>
       </div>
 


### PR DESCRIPTION
## Summary

Changed the run list fetch logic to use `YYYY-MM-DD.jsonl` instead of `YYYY-MM-DD.txt`.

### Changes

- **api.ts**: Updated `fetchRunList` to fetch from `metadata/{date}.jsonl` instead of `metadata/{date}.txt`
- **api.ts**: Parse JSONL format - reads `path` field as `slug` and maps `cancel` status to `cancelled`
- **api.ts**: Removed unused `parseRunListLine` function and `VALID_STATUSES` constant
- **api.test.ts**: Updated tests to use JSONL format

### Rationale

The `YYYY-MM-DD.jsonl` file contains all relevant fields for the list, requiring loading only a single file per day (no need to look for individual params.json or status files).

Fixes #154

## Testing Notes

The Vercel preview deployment is available at:
https://eval-monitor-opymduokk-openhands.vercel.app/