### PR TITLE
Add 'See in Trajectory Visualizer' button to results archive section

### DIFF
--- a/frontend/src/__tests__/CompletedRunResults.test.tsx
+++ b/frontend/src/__tests__/CompletedRunResults.test.tsx
@@ -120,4 +120,30 @@ describe('CompletedRunResults', () => {
       await screen.findByText('Copy archive link and submit to index')
     })
   })
+
+  describe('Trajectory Visualizer button', () => {
+    it('renders the "See in Trajectory Visualizer" button', async () => {
+      mockFetchWithCost(1.2345)
+
+      render(<CompletedRunResults slug="swebench/model/123" />)
+
+      await screen.findByText('See in Trajectory Visualizer')
+    })
+
+    it('links to the trajectory visualizer with the correct URL', async () => {
+      mockFetchWithCost(1.2345)
+
+      render(<CompletedRunResults slug="swebench/litellm_proxy-minimax-MiniMax-M2-7/24458507797" />)
+
+      const link = await screen.findByText('See in Trajectory Visualizer')
+      const anchor = link.closest('a')
+      expect(anchor).not.toBeNull()
+      expect(anchor?.href).toBe(
+        'https://trajectory-visualizer.all-hands.dev/?inUrl=' +
+        encodeURIComponent('https://results.eval.all-hands.dev/swebench/litellm_proxy-minimax-MiniMax-M2-7/24458507797/results.tar.gz')
+      )
+      expect(anchor?.target).toBe('_blank')
+      expect(anchor?.rel).toContain('noopener')
+    })
+  })
 })

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -124,6 +124,7 @@ function CostReportCard({ report }: { report: CostReport }) {
 function ArchiveLink({ slug }: { slug: string }) {
   const archiveUrl = getResultsUrl(slug, 'results.tar.gz')
   const PUSH_TO_INDEX_URL = 'https://github.com/OpenHands/evaluation/actions/workflows/push-to-index.yml'
+  const trajectoryVisualizerUrl = `https://trajectory-visualizer.all-hands.dev/?inUrl=${encodeURIComponent(archiveUrl)}`
 
   const handleCopyAndOpen = async () => {
     await navigator.clipboard.writeText(archiveUrl)
@@ -147,6 +148,18 @@ function ArchiveLink({ slug }: { slug: string }) {
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
           </svg>
           Download results.tar.gz
+        </a>
+        <a
+          href={trajectoryVisualizerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-3 py-1.5 bg-oh-primary/10 text-oh-primary border border-oh-primary/30 rounded-md text-sm font-medium hover:bg-oh-primary/20 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+          </svg>
+          See in Trajectory Visualizer
         </a>
         <button
           onClick={handleCopyAndOpen}

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -153,7 +153,7 @@ function ArchiveLink({ slug }: { slug: string }) {
           href={trajectoryVisualizerUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 px-3 py-1.5 bg-oh-primary/10 text-oh-primary border border-oh-primary/30 rounded-md text-sm font-medium hover:bg-oh-primary/20 transition-colors"
+          className="inline-flex items-center gap-2 px-3 py-1.5 bg-oh-purple/10 text-oh-purple border border-oh-purple/30 rounded-md text-sm font-medium hover:bg-oh-purple/20 transition-colors"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -20,6 +20,7 @@ export default {
           'warning': '#F59E0B',
           'error': '#EF4444',
           'info': '#38BDF8',
+          'purple': '#A855F7',
         }
       }
     },


### PR DESCRIPTION
## Summary

This PR adds a "See in Trajectory Visualizer" button in the results.tar.gz section (Results Archive) of the run detail view.

Fixes #158

## Changes

- Added a new button in the `ArchiveLink` component that links to the trajectory visualizer
- URL format: `https://trajectory-visualizer.all-hands.dev/?inUrl={encoded results.tar.gz URL}`
- The button opens in a new tab, similar to the other buttons in the section
- Uses an eye icon to represent "viewing" the trajectory
- Added tests to verify the button renders correctly and links to the proper URL

## Screenshot

The new button appears in the Results Archive section alongside the existing "Download results.tar.gz" and "Copy archive link and submit to index" buttons:

```
[📦 Results Archive]
[Download results.tar.gz] [See in Trajectory Visualizer] [Copy archive link and submit to index]
```

## Testing

- Added unit tests for the new Trajectory Visualizer button
- Tests verify:
  - Button renders with correct text
  - Button links to the correct trajectory visualizer URL with properly encoded archive URL
  - Button opens in a new tab (`target="_blank"`)

All tests pass for the CompletedRunResults component.

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4bd5e320-1a3c-435e-84a6-7e345be49c2a)