### PR TITLE
feat: Add new parameters to copy command button

### DIFF
--- a/frontend/src/components/CopyCommandButton.test.tsx
+++ b/frontend/src/components/CopyCommandButton.test.tsx
@@ -53,6 +53,7 @@ describe('CopyCommandButton', () => {
       trigger_reason: 'test eval-job-id',
       evaluation_branch: 'refs/heads/main',
       benchmarks_branch: 'main',
+      extensions_branch: null,
       instance_ids: null,
       num_infer_workers: null,
       num_eval_workers: null,
@@ -76,6 +77,7 @@ describe('CopyCommandButton', () => {
     expect(call).toContain('-f reason="test eval-job-id"')
     expect(call).toContain('-f eval_branch="main"')
     expect(call).toContain('-f benchmarks_branch="main"')
+    expect(call).toContain('-f extensions_branch=""')
     expect(call).toContain('-f instance_ids=""')
     expect(call).toContain('-f enable_conversation_event_logging="true"')
     expect(call).toContain('-f max_retries="3"')
@@ -161,5 +163,59 @@ describe('CopyCommandButton', () => {
 
     const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
     expect(call).toContain('-f sdk_ref="abc123def456"')
+  })
+
+  it('extracts extensions_branch and strips refs/heads/', () => {
+    const data = {
+      benchmark: 'swebench',
+      model_id: 'claude-sonnet-4',
+      extensions_branch: 'refs/heads/my-extension-branch',
+    }
+
+    render(<CopyCommandButton data={data} />)
+
+    const copyButton = screen.getByTitle('Copy gh workflow run command')
+    fireEvent.click(copyButton)
+
+    const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(call).toContain('-f extensions_branch="my-extension-branch"')
+    expect(call).not.toContain('refs/heads/my-extension-branch')
+  })
+
+  it('uses data values for enable_conversation_event_logging, max_retries, tool_preset when provided', () => {
+    const data = {
+      benchmark: 'swebench',
+      model_id: 'claude-sonnet-4',
+      enable_conversation_event_logging: false,
+      max_retries: 5,
+      tool_preset: 'custom',
+    }
+
+    render(<CopyCommandButton data={data} />)
+
+    const copyButton = screen.getByTitle('Copy gh workflow run command')
+    fireEvent.click(copyButton)
+
+    const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(call).toContain('-f enable_conversation_event_logging="false"')
+    expect(call).toContain('-f max_retries="5"')
+    expect(call).toContain('-f tool_preset="custom"')
+  })
+
+  it('uses default values for enable_conversation_event_logging, max_retries, tool_preset when not provided', () => {
+    const data = {
+      benchmark: 'swebench',
+      model_id: 'claude-sonnet-4',
+    }
+
+    render(<CopyCommandButton data={data} />)
+
+    const copyButton = screen.getByTitle('Copy gh workflow run command')
+    fireEvent.click(copyButton)
+
+    const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(call).toContain('-f enable_conversation_event_logging="true"')
+    expect(call).toContain('-f max_retries="3"')
+    expect(call).toContain('-f tool_preset="default"')
   })
 })

--- a/frontend/src/components/CopyCommandButton.tsx
+++ b/frontend/src/components/CopyCommandButton.tsx
@@ -56,6 +56,13 @@ function extractWorkflowInputs(data: Record<string, unknown>): Record<string, st
     params['benchmarks_branch'] = ''
   }
 
+  // extensions_branch (strip refs/heads/)
+  if (data.extensions_branch && typeof data.extensions_branch === 'string') {
+    params['extensions_branch'] = stripRefsPrefix(data.extensions_branch)
+  } else {
+    params['extensions_branch'] = ''
+  }
+
   // instance_ids
   params['instance_ids'] = valueToString(data.instance_ids)
 
@@ -65,14 +72,17 @@ function extractWorkflowInputs(data: Record<string, unknown>): Record<string, st
   // num_eval_workers
   params['num_eval_workers'] = valueToString(data.num_eval_workers)
 
-  // enable_conversation_event_logging (always true)
-  params['enable_conversation_event_logging'] = 'true'
+  // enable_conversation_event_logging (use data value or default to true)
+  const eventLoggingValue = valueToString(data.enable_conversation_event_logging)
+  params['enable_conversation_event_logging'] = eventLoggingValue || 'true'
 
-  // max_retries (always 3)
-  params['max_retries'] = '3'
+  // max_retries (use data value or default to 3)
+  const maxRetriesValue = valueToString(data.max_retries)
+  params['max_retries'] = maxRetriesValue || '3'
 
-  // tool_preset (always default)
-  params['tool_preset'] = 'default'
+  // tool_preset (use data value or default to 'default')
+  const toolPresetValue = valueToString(data.tool_preset)
+  params['tool_preset'] = toolPresetValue || 'default'
 
   // agent_type
   params['agent_type'] = valueToString(data.agent_type)


### PR DESCRIPTION
## Summary

This PR adds support for additional parameters in the Copy Command button as requested in issue #160.

## Changes

**New parameter:**
- `extensions_branch` - Now extracted from data with `refs/heads/` prefix stripping (same as other branch parameters)

**Parameters now dynamically extracted from data instead of hardcoded:**
- `enable_conversation_event_logging` - Now uses value from data, defaults to `true` if not present
- `max_retries` - Now uses value from data, defaults to `3` if not present
- `tool_preset` - Now uses value from data, defaults to `default` if not present

**Parameters already supported (no changes needed):**
- `instance_ids` - Already extracted from data
- `num_infer_workers` - Already extracted from data
- `num_eval_workers` - Already extracted from data
- `agent_type` - Already extracted from data

## Testing

Added new tests to verify:
1. `extensions_branch` is properly extracted and `refs/heads/` prefix is stripped
2. Parameters use data values when provided
3. Parameters fall back to defaults when not provided

All CopyCommandButton tests pass (12/12).

Fixes #160

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/07579805-b05a-4776-911e-1a3467a0f4a6)