### PR TITLE
fix #163: Remove build_action field and add links for github_run_id and unique_eval_name

### DIFF
--- a/frontend/src/__tests__/JsonCardLinks.test.tsx
+++ b/frontend/src/__tests__/JsonCardLinks.test.tsx
@@ -68,29 +68,42 @@ describe('JsonCard repo links', () => {
     expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/benchmarks/tree/my-bench-branch')
   })
 
-  it('links build_action to the benchmarks actions page with a query filter', () => {
+  it('links github_run_id to the evaluation actions run page', () => {
     render(
       <JsonCard
         title="Parameters"
         icon="⚙️"
-        data={{ build_action: 'dispatch-23910750652-claude-4-6' }}
+        data={{ github_run_id: '23910750652' }}
       />
     )
 
-    const link = screen.getByRole('link', { name: 'dispatch-23910750652-claude-4-6' })
-    expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/benchmarks/actions?query=branch%3Adispatch-23910750652-claude-4-6')
+    const link = screen.getByRole('link', { name: '23910750652' })
+    expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/evaluation/actions/runs/23910750652')
   })
 
-  it('does not link build_action values that do not start with dispatch-', () => {
+  it('does not link github_run_id if value is not numeric', () => {
     render(
       <JsonCard
         title="Parameters"
         icon="⚙️"
-        data={{ build_action: 'other-value' }}
+        data={{ github_run_id: 'not-a-number' }}
       />
     )
 
     expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('links unique_eval_name to the evaluation actions run page', () => {
+    render(
+      <JsonCard
+        title="Parameters"
+        icon="⚙️"
+        data={{ unique_eval_name: 'eval-2025-01-15-claude-4' }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'eval-2025-01-15-claude-4' })
+    expect(link.getAttribute('href')).toBe('https://github.com/OpenHands/evaluation/actions/runs/eval-2025-01-15-claude-4')
   })
 })
 

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -354,56 +354,10 @@ describe('augmentParams', () => {
     expect(augmentParams(null)).toBeNull()
   })
 
-  it('synthesizes build_action from github_run_id and model_id and inserts it after sdk_commit', () => {
+  it('returns params unchanged (build_action is no longer synthesized)', () => {
     const params = { sdk_commit: 'abc123', github_run_id: '23459137418', model_id: 'claude-4-6', eval_limit: 5 }
-    const result = augmentParams(params)!
-    const keys = Object.keys(result)
-    expect(result.build_action).toBe('dispatch-23459137418-claude-4-6')
-    expect(keys.indexOf('build_action')).toBe(keys.indexOf('sdk_commit') + 1)
-  })
-
-  it('synthesizes build_action from github_run_id only when model_id is missing', () => {
-    const params = { sdk_commit: 'abc123', github_run_id: '23459137418', eval_limit: 5 }
-    const result = augmentParams(params)!
-    const keys = Object.keys(result)
-    expect(result.build_action).toBe('dispatch-23459137418')
-    expect(keys.indexOf('build_action')).toBe(keys.indexOf('sdk_commit') + 1)
-  })
-
-  it('uses first 10 chars of model_id (without dots) in build_action', () => {
-    const params = { github_run_id: '99999', model_id: 'gemini-3-flash-pro' }
-    const result = augmentParams(params)!
-    expect(result.build_action).toBe('dispatch-99999-gemini-3-f')
-  })
-
-  it('replaces dots with hyphens in model_id before taking first 10 chars', () => {
-    const params = { github_run_id: '12345', model_id: 'claude-sonnet-4.5' }
-    const result = augmentParams(params)!
-    // "claude-sonnet-4.5" -> "claude-sonnet-4-5" -> "claude-son" (first 10)
-    expect(result.build_action).toBe('dispatch-12345-claude-son')
-  })
-
-  it('appends build_action at the end when sdk_commit is absent', () => {
-    const params = { eval_limit: 5, github_run_id: '99999', model_id: 'claude-4' }
-    const result = augmentParams(params)!
-    const keys = Object.keys(result)
-    expect(result.build_action).toBe('dispatch-99999-claude-4')
-    expect(keys[keys.length - 1]).toBe('build_action')
-  })
-
-  it('does not override an existing build_action', () => {
-    const params = { sdk_commit: 'abc', build_action: 'dispatch-existing', github_run_id: '111' }
-    const result = augmentParams(params)!
-    expect(result.build_action).toBe('dispatch-existing')
-  })
-
-  it('returns params unchanged when github_run_id is missing', () => {
-    const params = { sdk_commit: 'abc', eval_limit: 5 }
-    expect(augmentParams(params)).toBe(params)
-  })
-
-  it('returns params unchanged when github_run_id is not a string', () => {
-    const params = { sdk_commit: 'abc', github_run_id: 12345 }
+    // The function now just returns params as-is since build_action is no longer needed
+    // (the eval action now contains both build and eval jobs)
     expect(augmentParams(params)).toBe(params)
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -174,26 +174,11 @@ async function fetchJson(url: string): Promise<Record<string, unknown> | null> {
   }
 }
 
-/** Synthesize a `build_action` field from `github_run_id` and `model_id` if not already present.
- *  Format: dispatch-{github_run_id}-{first 10 chars of model_id with dots replaced by hyphens}
- *  inserting it immediately after `sdk_commit` so it appears under it in the UI. */
+/** Augment params with additional derived fields if needed.
+ *  Currently just returns params as-is since build_action is no longer synthesized
+ *  (the eval action now contains both build and eval jobs). */
 export function augmentParams(params: Record<string, unknown> | null): Record<string, unknown> | null {
-  if (!params) return params
-  if (params.build_action || !params.github_run_id || typeof params.github_run_id !== 'string') return params
-
-  const modelId = typeof params.model_id === 'string' ? params.model_id.replace(/\./g, '-').slice(0, 10) : ''
-  const buildAction = modelId ? `dispatch-${params.github_run_id}-${modelId}` : `dispatch-${params.github_run_id}`
-  const augmented: Record<string, unknown> = {}
-  let inserted = false
-  for (const [key, value] of Object.entries(params)) {
-    augmented[key] = value
-    if (key === 'sdk_commit' && !inserted) {
-      augmented['build_action'] = buildAction
-      inserted = true
-    }
-  }
-  if (!inserted) augmented['build_action'] = buildAction
-  return augmented
+  return params
 }
 
 export async function fetchRunMetadata(runSlug: string): Promise<RunMetadata> {

--- a/frontend/src/components/JsonCard.tsx
+++ b/frontend/src/components/JsonCard.tsx
@@ -17,6 +17,7 @@ const SDK_WORKFLOW_RUN_BASE_URL = 'https://github.com/OpenHands/software-agent-s
 const EVAL_BRANCH_BASE_URL = 'https://github.com/OpenHands/evaluation/tree/'
 const BENCHMARKS_BRANCH_BASE_URL = 'https://github.com/OpenHands/benchmarks/tree/'
 const BENCHMARKS_ACTIONS_BASE_URL = 'https://github.com/OpenHands/benchmarks/actions'
+const EVAL_ACTIONS_RUN_BASE_URL = 'https://github.com/OpenHands/evaluation/actions/runs/'
 
 const SHA_RE = /^[0-9a-f]{7,40}$/i
 const GIT_REFS_HEADS_PREFIX = 'refs/heads/'
@@ -143,8 +144,13 @@ function getLinkForKeyValue(key: string, value: unknown): { href: string; text: 
     return { href: `${BENCHMARKS_BRANCH_BASE_URL}${branch}`, text: branch }
   }
 
-  if (keyLower.includes('build_action') && value.startsWith('dispatch-')) {
-    return { href: `${BENCHMARKS_ACTIONS_BASE_URL}?query=${encodeURIComponent('branch:' + value)}`, text: value }
+  if (keyLower.includes('github_run_id') && /^\d+$/.test(value)) {
+    return { href: `${EVAL_ACTIONS_RUN_BASE_URL}${value}`, text: value }
+  }
+
+  if (keyLower.includes('unique_eval_name')) {
+    // unique_eval_name is typically a string that identifies the eval run
+    return { href: `${EVAL_ACTIONS_RUN_BASE_URL}${value}`, text: value }
   }
 
   return null


### PR DESCRIPTION
## Summary

Fixes issue #163 by making the following changes:

1. **Remove `build_action` field**: The `build_action` field is no longer synthesized in the `augmentParams` function since the eval action now contains both the build job and other jobs.

2. **Add URL links for `github_run_id` and `unique_eval_name`**: Both fields now act as URL links pointing to `https://github.com/OpenHands/evaluation/actions/runs/{value}`.

## Changes Made

- `frontend/src/api.ts`: Simplified `augmentParams` to return params as-is (no longer synthesizes `build_action`)
- `frontend/src/components/JsonCard.tsx`: Added link handling for `github_run_id` and `unique_eval_name` to point to evaluation actions runs
- Updated tests in `frontend/src/api.test.ts` and `frontend/src/__tests__/JsonCardLinks.test.tsx`

## Testing

All related tests pass:
- `src/api.test.ts` (49 tests)
- `src/__tests__/JsonCardLinks.test.tsx` (14 tests)

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7457aea5-562b-47cc-9e12-7aa0c7e71d7d)