### PR TITLE
Fix frozen Runtime column and empty Eval Time badge on list view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -209,7 +209,7 @@ export default function App() {
     const parsed = parseRunSlug(runItem.slug)
     // Use model/runtime from JSONL if available, otherwise parse from path
     const model = runItem.model || parsed.model
-    return { slug: runItem.slug, status: runItem.status, triggeredBy: runItem.triggeredBy, triggerReason: runItem.triggerReason, benchmark: parsed.benchmark, jobId: parsed.jobId, model, runtime: runItem.runtime }
+    return { slug: runItem.slug, status: runItem.status, triggeredBy: runItem.triggeredBy, triggerReason: runItem.triggerReason, benchmark: parsed.benchmark, jobId: parsed.jobId, model, initTimestamp: runItem.initTimestamp, endTimestamp: runItem.endTimestamp }
   }), [runs])
 
   return (

--- a/frontend/src/__tests__/ActiveWorkersBadge.test.tsx
+++ b/frontend/src/__tests__/ActiveWorkersBadge.test.tsx
@@ -48,7 +48,7 @@ describe('ActiveWorkersBadge', () => {
         createRun('swebench/qwen/123', 'juanmichelini', 'completed'),
         createRun('gaia/claude/456', 'admin', 'error'),
       ]
-      const { container } = render(
+      render(
         <ActiveWorkersBadge runMetadataMap={{}} runs={completedRuns} />
       )
       expect(screen.getByText('Active workers: 0')).toBeTruthy()

--- a/frontend/src/__tests__/RunListView.test.tsx
+++ b/frontend/src/__tests__/RunListView.test.tsx
@@ -236,13 +236,13 @@ describe('RunListView', () => {
 
     const activeStatusProps = {
       runs: [
-        { slug: 'swebench/pending-run/1', benchmark: 'swebench', model: 'pending-run', jobId: '1' },
-        { slug: 'swebench/building-run/2', benchmark: 'swebench', model: 'building-run', jobId: '2' },
-        { slug: 'swebench/infer-run/3', benchmark: 'swebench', model: 'infer-run', jobId: '3' },
-        { slug: 'swebench/eval-run/4', benchmark: 'swebench', model: 'eval-run', jobId: '4' },
-        { slug: 'swebench/completed-run/5', benchmark: 'swebench', model: 'completed-run', jobId: '5' },
-        { slug: 'swebench/error-run/6', benchmark: 'swebench', model: 'error-run', jobId: '6' },
-        { slug: 'swebench/cancelled-run/7', benchmark: 'swebench', model: 'cancelled-run', jobId: '7' }
+        { slug: 'swebench/pending-run/1', benchmark: 'swebench', model: 'pending-run', jobId: '1', status: 'pending' as const },
+        { slug: 'swebench/building-run/2', benchmark: 'swebench', model: 'building-run', jobId: '2', status: 'building' as const },
+        { slug: 'swebench/infer-run/3', benchmark: 'swebench', model: 'infer-run', jobId: '3', status: 'running-infer' as const },
+        { slug: 'swebench/eval-run/4', benchmark: 'swebench', model: 'eval-run', jobId: '4', status: 'running-eval' as const },
+        { slug: 'swebench/completed-run/5', benchmark: 'swebench', model: 'completed-run', jobId: '5', status: 'completed' as const },
+        { slug: 'swebench/error-run/6', benchmark: 'swebench', model: 'error-run', jobId: '6', status: 'error' as const },
+        { slug: 'swebench/cancelled-run/7', benchmark: 'swebench', model: 'cancelled-run', jobId: '7', status: 'cancelled' as const }
       ],
       loading: false,
       error: null,

--- a/frontend/src/__tests__/eval-time.test.ts
+++ b/frontend/src/__tests__/eval-time.test.ts
@@ -1,41 +1,33 @@
 import { describe, it, expect } from 'vitest'
 import { computeEvalTimeReport, EVAL_TIME_WARNING_MS, EVAL_TIME_CRITICAL_MS } from '../api'
-import type { RunMetadata } from '../api'
+import type { RunListItem, RunListItemStatus } from '../api'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Build a RunMetadata where every field is null by default. Pass overrides to
- *  set specific stage records, each optionally carrying a timestamp. */
-function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
-  return {
-    init: null,
-    params: null,
-    error: null,
-    runInferStart: null,
-    runInferEnd: null,
-    evalInferStart: null,
-    evalInferEnd: null,
-    cancelEval: null,
-    ...overrides,
-  }
-}
 
 /** Return an ISO timestamp string that is `offsetMs` milliseconds before `now`. */
 function tsAgo(now: number, offsetMs: number): string {
   return new Date(now - offsetMs).toISOString()
 }
 
+/** Build a minimal RunListItem, overriding whatever fields the test needs. */
+function makeRun(overrides: Partial<RunListItem> & { slug?: string } = {}): RunListItem {
+  return {
+    slug: 'bench/model/1',
+    ...overrides,
+  }
+}
+
 // A fixed "now" used throughout so elapsed times are deterministic.
 const NOW = 1_700_000_000_000
 
 // Convenient elapsed-time constants relative to the thresholds.
-const UNDER_WARNING = EVAL_TIME_WARNING_MS - 1          // 1 ms under 10 h
-const AT_WARNING    = EVAL_TIME_WARNING_MS              // exactly 10 h
-const BETWEEN       = EVAL_TIME_WARNING_MS + 1_000_000  // ~10 h 16 m 40 s
-const AT_CRITICAL   = EVAL_TIME_CRITICAL_MS             // exactly 24 h
-const OVER_CRITICAL = EVAL_TIME_CRITICAL_MS + 1         // 1 ms over 24 h
+const UNDER_WARNING = EVAL_TIME_WARNING_MS - 1
+const AT_WARNING    = EVAL_TIME_WARNING_MS
+const BETWEEN       = EVAL_TIME_WARNING_MS + 1_000_000
+const AT_CRITICAL   = EVAL_TIME_CRITICAL_MS
+const OVER_CRITICAL = EVAL_TIME_CRITICAL_MS + 1
 
 // ---------------------------------------------------------------------------
 // computeEvalTimeReport
@@ -43,86 +35,65 @@ const OVER_CRITICAL = EVAL_TIME_CRITICAL_MS + 1         // 1 ms over 24 h
 
 describe('computeEvalTimeReport', () => {
 
-  // -------------------------------------------------------------------------
-  // Empty / trivial input
-  // -------------------------------------------------------------------------
-
-  describe('empty metadataMap', () => {
+  describe('empty input', () => {
     it('returns healthy state with zero entries and zero totalActive', () => {
-      const report = computeEvalTimeReport({}, {}, NOW)
+      const report = computeEvalTimeReport([], NOW)
       expect(report.state).toBe('healthy')
       expect(report.entries).toEqual([])
       expect(report.totalActive).toBe(0)
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Finished runs are skipped entirely
-  // -------------------------------------------------------------------------
+  describe('runs without a status', () => {
+    it('ignores runs that have no status at all', () => {
+      const run = makeRun({ slug: 'a/b/1', initTimestamp: tsAgo(NOW, AT_CRITICAL) })
+      const report = computeEvalTimeReport([run], NOW)
+      expect(report.state).toBe('healthy')
+      expect(report.totalActive).toBe(0)
+      expect(report.entries).toEqual([])
+    })
+  })
 
   describe('finished runs', () => {
-    it('skips completed runs', () => {
-      const metadata = makeMetadata({ evalInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-      expect(report.state).toBe('healthy')
-      expect(report.entries).toEqual([])
-      expect(report.totalActive).toBe(0)
-    })
+    const finishedStatuses: RunListItemStatus[] = ['completed', 'error', 'cancelled']
 
-    it('skips error runs', () => {
-      const metadata = makeMetadata({ error: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-      expect(report.state).toBe('healthy')
-      expect(report.entries).toEqual([])
-      expect(report.totalActive).toBe(0)
-    })
+    for (const status of finishedStatuses) {
+      it(`skips ${status} runs entirely`, () => {
+        const run = makeRun({ status, initTimestamp: tsAgo(NOW, OVER_CRITICAL) })
+        const report = computeEvalTimeReport([run], NOW)
+        expect(report.state).toBe('healthy')
+        expect(report.entries).toEqual([])
+        expect(report.totalActive).toBe(0)
+      })
+    }
 
-    it('skips cancelled runs', () => {
-      const metadata = makeMetadata({ cancelEval: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-      expect(report.state).toBe('healthy')
-      expect(report.entries).toEqual([])
-      expect(report.totalActive).toBe(0)
-    })
-
-    it('skips all three finished statuses and reports zero totalActive', () => {
-      const completed = makeMetadata({ evalInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const errored   = makeMetadata({ error: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const cancelled = makeMetadata({ cancelEval: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport(
-        { 'a/b/1': completed, 'a/b/2': errored, 'a/b/3': cancelled },
-        {},
-        NOW,
-      )
+    it('skips all three finished statuses together', () => {
+      const runs: RunListItem[] = [
+        { slug: 'a/b/1', status: 'completed', initTimestamp: tsAgo(NOW, OVER_CRITICAL) },
+        { slug: 'a/b/2', status: 'error',     initTimestamp: tsAgo(NOW, OVER_CRITICAL) },
+        { slug: 'a/b/3', status: 'cancelled', initTimestamp: tsAgo(NOW, OVER_CRITICAL) },
+      ]
+      const report = computeEvalTimeReport(runs, NOW)
       expect(report.state).toBe('healthy')
       expect(report.entries).toEqual([])
       expect(report.totalActive).toBe(0)
     })
   })
-
-  // -------------------------------------------------------------------------
-  // Active run under the warning threshold → healthy
-  // -------------------------------------------------------------------------
 
   describe('active run under warning threshold', () => {
     it('counts the run in totalActive but emits no entries and stays healthy', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, UNDER_WARNING) } })
-      // getStageStatus will return 'building' (params present, nothing else)
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, UNDER_WARNING) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.state).toBe('healthy')
       expect(report.entries).toEqual([])
       expect(report.totalActive).toBe(1)
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Threshold boundary: warning
-  // -------------------------------------------------------------------------
-
   describe('warning threshold boundary', () => {
     it('triggers warning when elapsed equals EVAL_TIME_WARNING_MS exactly', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, AT_WARNING) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.state).toBe('warning')
       expect(report.entries).toHaveLength(1)
       expect(report.entries[0].elapsedMs).toBe(AT_WARNING)
@@ -130,390 +101,221 @@ describe('computeEvalTimeReport', () => {
     })
 
     it('emits an entry for a run between warning and critical thresholds', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, BETWEEN) } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, BETWEEN) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.state).toBe('warning')
       expect(report.entries).toHaveLength(1)
       expect(report.entries[0].elapsedMs).toBe(BETWEEN)
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Threshold boundary: critical
-  // -------------------------------------------------------------------------
-
   describe('critical threshold boundary', () => {
     it('triggers critical when elapsed equals EVAL_TIME_CRITICAL_MS exactly', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, AT_CRITICAL) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.state).toBe('critical')
       expect(report.entries).toHaveLength(1)
       expect(report.entries[0].elapsedMs).toBe(AT_CRITICAL)
     })
 
     it('triggers critical when elapsed exceeds EVAL_TIME_CRITICAL_MS', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, OVER_CRITICAL) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.state).toBe('critical')
       expect(report.entries).toHaveLength(1)
       expect(report.entries[0].elapsedMs).toBe(OVER_CRITICAL)
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Mixed warning + critical → overall state is critical
-  // -------------------------------------------------------------------------
-
   describe('mix of warning and critical entries', () => {
     it('reports critical when any entry reaches EVAL_TIME_CRITICAL_MS', () => {
-      const warnRun     = makeMetadata({ params: { timestamp: tsAgo(NOW, BETWEEN) } })
-      const criticalRun = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
-      const report = computeEvalTimeReport(
-        { 'slug/warn/1': warnRun, 'slug/crit/1': criticalRun },
-        {},
-        NOW,
-      )
+      const runs: RunListItem[] = [
+        { slug: 'a/warn/1', status: 'building', initTimestamp: tsAgo(NOW, BETWEEN) },
+        { slug: 'a/crit/1', status: 'building', initTimestamp: tsAgo(NOW, AT_CRITICAL) },
+      ]
+      const report = computeEvalTimeReport(runs, NOW)
       expect(report.state).toBe('critical')
       expect(report.entries).toHaveLength(2)
       expect(report.totalActive).toBe(2)
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Sorting: longest-running first
-  // -------------------------------------------------------------------------
-
   describe('sorting', () => {
     it('returns entries sorted longest elapsed time first', () => {
-      const slow     = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
-      const moderate = makeMetadata({ params: { timestamp: tsAgo(NOW, BETWEEN) } })
-      const fastest  = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
-      const report = computeEvalTimeReport(
-        { 'slug/fast/1': fastest, 'slug/slow/1': slow, 'slug/mod/1': moderate },
-        {},
-        NOW,
-      )
-      expect(report.entries[0].elapsedMs).toBeGreaterThanOrEqual(report.entries[1].elapsedMs)
-      expect(report.entries[1].elapsedMs).toBeGreaterThanOrEqual(report.entries[2].elapsedMs)
-      // The absolute values must match too
+      const runs: RunListItem[] = [
+        { slug: 'fast',  status: 'building', initTimestamp: tsAgo(NOW, AT_WARNING) },
+        { slug: 'slow',  status: 'building', initTimestamp: tsAgo(NOW, AT_CRITICAL) },
+        { slug: 'mod',   status: 'building', initTimestamp: tsAgo(NOW, BETWEEN) },
+      ]
+      const report = computeEvalTimeReport(runs, NOW)
       expect(report.entries[0].elapsedMs).toBe(AT_CRITICAL)
       expect(report.entries[1].elapsedMs).toBe(BETWEEN)
       expect(report.entries[2].elapsedMs).toBe(AT_WARNING)
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Stage labels
-  // -------------------------------------------------------------------------
-
   describe('stageLabel per status', () => {
     it('produces "Building" for building status', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
-      // getStageStatus → 'building' (params present, no other signals)
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, AT_WARNING) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries[0].stageLabel).toBe('Building')
       expect(report.entries[0].status).toBe('building')
     })
 
     it('produces "Inference" for running-infer status', () => {
-      const metadata = makeMetadata({
-        params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-        init: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-        runInferStart: { timestamp: tsAgo(NOW, AT_WARNING) },
+      const run = makeRun({
+        status: 'running-infer',
+        initTimestamp: tsAgo(NOW, OVER_CRITICAL),
+        inferStartTimestamp: tsAgo(NOW, AT_WARNING),
       })
-      // getStageStatus → 'running-infer' (runInferStart present, no runInferEnd)
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries[0].stageLabel).toBe('Inference')
       expect(report.entries[0].status).toBe('running-infer')
     })
 
-    it('produces "Evaluation" for running-eval status via evalInferStart', () => {
-      const metadata = makeMetadata({
-        params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-        runInferStart: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-        runInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-        evalInferStart: { timestamp: tsAgo(NOW, AT_WARNING) },
+    it('produces "Evaluation" for running-eval status', () => {
+      const run = makeRun({
+        status: 'running-eval',
+        initTimestamp: tsAgo(NOW, OVER_CRITICAL),
+        inferStartTimestamp: tsAgo(NOW, OVER_CRITICAL),
+        evalStartTimestamp: tsAgo(NOW, AT_WARNING),
       })
-      // getStageStatus → 'running-eval' (evalInferStart present, no evalInferEnd)
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries[0].stageLabel).toBe('Evaluation')
       expect(report.entries[0].status).toBe('running-eval')
     })
 
     it('produces "Pending" for pending status', () => {
-      const metadata = makeMetadata({ init: { timestamp: tsAgo(NOW, AT_WARNING) } })
-      // getStageStatus → 'pending' (init present, no params)
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+      const run = makeRun({ status: 'pending', initTimestamp: tsAgo(NOW, AT_WARNING) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries[0].stageLabel).toBe('Pending')
       expect(report.entries[0].status).toBe('pending')
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Stage start timestamp selection
-  // -------------------------------------------------------------------------
-
-  describe('stageStartMs timestamp selection', () => {
-    describe('building stage uses params.timestamp', () => {
-      it('uses params.timestamp as the start time for building runs', () => {
-        const startMs = AT_WARNING + 5000
-        const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, startMs) } })
-        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-        expect(report.entries[0].elapsedMs).toBe(startMs)
-      })
-    })
-
-    describe('running-infer stage uses runInferStart.timestamp', () => {
-      it('uses runInferStart.timestamp as the start time', () => {
-        const startMs = AT_WARNING + 7000
-        const metadata = makeMetadata({
-          params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-          init: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-          runInferStart: { timestamp: tsAgo(NOW, startMs) },
-        })
-        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-        expect(report.entries[0].status).toBe('running-infer')
-        expect(report.entries[0].elapsedMs).toBe(startMs)
-      })
-    })
-
-    describe('running-eval stage uses evalInferStart.timestamp with runInferEnd fallback', () => {
-      it('uses evalInferStart.timestamp when present', () => {
-        const startMs = AT_WARNING + 3000
-        const metadata = makeMetadata({
-          params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-          runInferStart: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-          runInferEnd: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-          evalInferStart: { timestamp: tsAgo(NOW, startMs) },
-        })
-        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-        expect(report.entries[0].status).toBe('running-eval')
-        expect(report.entries[0].elapsedMs).toBe(startMs)
-      })
-
-      it('falls back to runInferEnd.timestamp when evalInferStart is absent', () => {
-        const startMs = AT_WARNING + 9000
-        const metadata = makeMetadata({
-          params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-          runInferStart: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-          runInferEnd: { timestamp: tsAgo(NOW, startMs) },
-          // evalInferStart is null — getStageStatus will still return 'running-eval'
-          // because runInferEnd is set
-        })
-        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-        expect(report.entries[0].status).toBe('running-eval')
-        expect(report.entries[0].elapsedMs).toBe(startMs)
-      })
-    })
-
-    describe('pending stage uses init.timestamp with params fallback', () => {
-      it('uses init.timestamp as the start time when present', () => {
-        const startMs = AT_WARNING + 2000
-        const metadata = makeMetadata({ init: { timestamp: tsAgo(NOW, startMs) } })
-        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-        expect(report.entries[0].status).toBe('pending')
-        expect(report.entries[0].elapsedMs).toBe(startMs)
-      })
-
-      it('falls back to params.timestamp when init has no timestamp', () => {
-        const startMs = AT_WARNING + 4000
-        const metadata = makeMetadata({
-          init: { some_other_field: 'value' },        // no timestamp
-          params: { timestamp: tsAgo(NOW, startMs) },
-        })
-        // getStageStatus: init present → 'pending'; stageStartMs: init ts null → falls back to params ts
-        const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-        expect(report.entries[0].status).toBe('pending')
-        expect(report.entries[0].elapsedMs).toBe(startMs)
-      })
-    })
-  })
-
-  // -------------------------------------------------------------------------
-  // preStatuses override
-  // -------------------------------------------------------------------------
-
-  describe('preStatuses override', () => {
-    it('uses the preStatus instead of deriving status from metadata', () => {
-      // Metadata alone would indicate 'building' (only params present, no infer data).
-      // We override to 'running-infer', so stageStartMs will look at runInferStart.
-      const startMs = AT_WARNING + 1000
-      const metadata = makeMetadata({
-        params: { timestamp: tsAgo(NOW, OVER_CRITICAL) },
-        runInferStart: { timestamp: tsAgo(NOW, startMs) },
-      })
-      const report = computeEvalTimeReport(
-        { 'slug/a/1': metadata },
-        { 'slug/a/1': 'running-infer' },
-        NOW,
-      )
-      expect(report.entries[0].status).toBe('running-infer')
+  describe('stage start timestamp selection', () => {
+    it('building stage uses initTimestamp as the start time', () => {
+      const startMs = AT_WARNING + 5000
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, startMs) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries[0].elapsedMs).toBe(startMs)
     })
 
-    it('treats a run as finished when preStatus is completed, skipping it', () => {
-      // Metadata alone would derive 'building'; preStatus overrides to 'completed'.
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport(
-        { 'slug/a/1': metadata },
-        { 'slug/a/1': 'completed' },
-        NOW,
-      )
-      expect(report.state).toBe('healthy')
-      expect(report.entries).toEqual([])
-      expect(report.totalActive).toBe(0)
+    it('pending stage uses initTimestamp as the start time', () => {
+      const startMs = AT_WARNING + 2000
+      const run = makeRun({ status: 'pending', initTimestamp: tsAgo(NOW, startMs) })
+      const report = computeEvalTimeReport([run], NOW)
+      expect(report.entries[0].elapsedMs).toBe(startMs)
     })
 
-    it('treats a run as finished when preStatus is error, skipping it', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport(
-        { 'slug/a/1': metadata },
-        { 'slug/a/1': 'error' },
-        NOW,
-      )
-      expect(report.totalActive).toBe(0)
+    it('running-infer stage uses inferStartTimestamp as the start time', () => {
+      const startMs = AT_WARNING + 7000
+      const run = makeRun({
+        status: 'running-infer',
+        initTimestamp: tsAgo(NOW, OVER_CRITICAL),
+        inferStartTimestamp: tsAgo(NOW, startMs),
+      })
+      const report = computeEvalTimeReport([run], NOW)
+      expect(report.entries[0].elapsedMs).toBe(startMs)
     })
 
-    it('treats a run as finished when preStatus is cancelled, skipping it', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport(
-        { 'slug/a/1': metadata },
-        { 'slug/a/1': 'cancelled' },
-        NOW,
-      )
-      expect(report.totalActive).toBe(0)
+    it('running-eval stage uses evalStartTimestamp when present', () => {
+      const startMs = AT_WARNING + 3000
+      const run = makeRun({
+        status: 'running-eval',
+        initTimestamp: tsAgo(NOW, OVER_CRITICAL),
+        inferStartTimestamp: tsAgo(NOW, OVER_CRITICAL),
+        evalStartTimestamp: tsAgo(NOW, startMs),
+      })
+      const report = computeEvalTimeReport([run], NOW)
+      expect(report.entries[0].elapsedMs).toBe(startMs)
     })
 
-    it('only applies preStatus override to the matching slug', () => {
-      const slow    = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
-      const overridden = makeMetadata({ params: { timestamp: tsAgo(NOW, OVER_CRITICAL) } })
-      const report = computeEvalTimeReport(
-        { 'slug/slow/1': slow, 'slug/done/1': overridden },
-        { 'slug/done/1': 'completed' },
-        NOW,
-      )
-      // Only 'slug/slow/1' should remain active
-      expect(report.totalActive).toBe(1)
-      expect(report.entries).toHaveLength(1)
-      expect(report.entries[0].slug).toBe('slug/slow/1')
+    it('running-eval falls back to inferStartTimestamp when evalStartTimestamp is absent', () => {
+      const startMs = AT_WARNING + 9000
+      const run = makeRun({
+        status: 'running-eval',
+        initTimestamp: tsAgo(NOW, OVER_CRITICAL),
+        inferStartTimestamp: tsAgo(NOW, startMs),
+      })
+      const report = computeEvalTimeReport([run], NOW)
+      expect(report.entries[0].elapsedMs).toBe(startMs)
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Missing timestamp → counted in totalActive but not in entries
-  // -------------------------------------------------------------------------
-
-  describe('run with no timestamp in stage metadata', () => {
-    it('counts the run in totalActive but excludes it from entries', () => {
-      // Status will be 'building' (params present), but params has no timestamp.
-      const metadata = makeMetadata({ params: { model_id: 'gpt-4' } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
+  describe('missing / invalid timestamp', () => {
+    it('counts the run in totalActive but excludes it from entries when timestamp is absent', () => {
+      const run = makeRun({ status: 'building' })  // no initTimestamp
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.state).toBe('healthy')
+      expect(report.entries).toEqual([])
+      expect(report.totalActive).toBe(1)
+    })
+
+    it('treats an unparseable timestamp as missing', () => {
+      const run = makeRun({ status: 'building', initTimestamp: 'not-a-date' })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries).toEqual([])
       expect(report.totalActive).toBe(1)
     })
 
     it('still counts correctly when mixed with slow runs that do have timestamps', () => {
-      const noTs = makeMetadata({ params: { model_id: 'gpt-4' } })
-      const slow = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_CRITICAL) } })
-      const report = computeEvalTimeReport(
-        { 'slug/no-ts/1': noTs, 'slug/slow/1': slow },
-        {},
-        NOW,
-      )
+      const runs: RunListItem[] = [
+        { slug: 'no-ts', status: 'building' },
+        { slug: 'slow',  status: 'building', initTimestamp: tsAgo(NOW, AT_CRITICAL) },
+      ]
+      const report = computeEvalTimeReport(runs, NOW)
       expect(report.totalActive).toBe(2)
       expect(report.entries).toHaveLength(1)
-      expect(report.entries[0].slug).toBe('slug/slow/1')
-    })
-
-    it('treats an invalid (non-parseable) timestamp as missing', () => {
-      const metadata = makeMetadata({ params: { timestamp: 'not-a-date' } })
-      const report = computeEvalTimeReport({ 'slug/a/1': metadata }, {}, NOW)
-      expect(report.entries).toEqual([])
-      expect(report.totalActive).toBe(1)
+      expect(report.entries[0].slug).toBe('slow')
     })
   })
 
-  // -------------------------------------------------------------------------
-  // Entry fields are correct
-  // -------------------------------------------------------------------------
-
   describe('entry shape', () => {
     it('populates all entry fields correctly', () => {
-      const metadata = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
-      const report = computeEvalTimeReport({ 'bench/model/42': metadata }, {}, NOW)
+      const run: RunListItem = {
+        slug: 'bench/model/42',
+        status: 'building',
+        initTimestamp: tsAgo(NOW, AT_WARNING),
+        triggeredBy: 'alice',
+      }
+      const report = computeEvalTimeReport([run], NOW)
       const entry = report.entries[0]
       expect(entry.slug).toBe('bench/model/42')
       expect(entry.status).toBe('building')
       expect(entry.stageLabel).toBe('Building')
       expect(entry.elapsedMs).toBe(AT_WARNING)
+      expect(entry.triggeredBy).toBe('alice')
     })
   })
 
-  // -------------------------------------------------------------------------
-  // triggeredBy is extracted from metadata
-  // -------------------------------------------------------------------------
-
   describe('triggeredBy', () => {
-    it('extracts triggeredBy from params.triggered_by', () => {
-      const metadata = makeMetadata({
-        params: { timestamp: tsAgo(NOW, AT_WARNING), triggered_by: 'juanmichelini' },
+    it('uses the RunListItem.triggeredBy value directly', () => {
+      const run = makeRun({
+        status: 'building',
+        initTimestamp: tsAgo(NOW, AT_WARNING),
+        triggeredBy: 'juanmichelini',
       })
-      const report = computeEvalTimeReport({ 'bench/model/1': metadata }, {}, NOW)
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries[0].triggeredBy).toBe('juanmichelini')
     })
 
-    it('extracts triggeredBy from init.actor as fallback', () => {
-      const metadata = makeMetadata({
-        params: { timestamp: tsAgo(NOW, AT_WARNING) },
-        init: { actor: 'alice' },
-      })
-      const report = computeEvalTimeReport({ 'bench/model/1': metadata }, {}, NOW)
-      expect(report.entries[0].triggeredBy).toBe('alice')
-    })
-
-    it('returns "—" when no trigger information is present', () => {
-      const metadata = makeMetadata({
-        params: { timestamp: tsAgo(NOW, AT_WARNING) },
-      })
-      const report = computeEvalTimeReport({ 'bench/model/1': metadata }, {}, NOW)
+    it('returns "—" when triggeredBy is not set', () => {
+      const run = makeRun({ status: 'building', initTimestamp: tsAgo(NOW, AT_WARNING) })
+      const report = computeEvalTimeReport([run], NOW)
       expect(report.entries[0].triggeredBy).toBe('—')
-    })
-
-    it('extracts different triggeredBy values for different entries', () => {
-      const metadata1 = makeMetadata({
-        params: { timestamp: tsAgo(NOW, AT_WARNING), triggered_by: 'user1' },
-      })
-      const metadata2 = makeMetadata({
-        params: { timestamp: tsAgo(NOW, AT_CRITICAL), triggered_by: 'user2' },
-      })
-      const report = computeEvalTimeReport(
-        { 'bench/model/1': metadata1, 'bench/model/2': metadata2 },
-        {},
-        NOW,
-      )
-      expect(report.entries).toHaveLength(2)
-      const triggeredBys = report.entries.map(e => e.triggeredBy).sort()
-      expect(triggeredBys).toEqual(['user1', 'user2'])
     })
   })
 
-  // -------------------------------------------------------------------------
-  // totalActive counts all non-finished runs regardless of threshold
-  // -------------------------------------------------------------------------
-
   describe('totalActive count', () => {
-    it('includes active runs that are below the warning threshold in totalActive', () => {
-      const active1 = makeMetadata({ params: { timestamp: tsAgo(NOW, UNDER_WARNING) } })
-      const active2 = makeMetadata({ params: { timestamp: tsAgo(NOW, AT_WARNING) } })
-      const report = computeEvalTimeReport(
-        { 'slug/a/1': active1, 'slug/b/1': active2 },
-        {},
-        NOW,
-      )
+    it('includes active runs that are below the warning threshold', () => {
+      const runs: RunListItem[] = [
+        { slug: 'a', status: 'building', initTimestamp: tsAgo(NOW, UNDER_WARNING) },
+        { slug: 'b', status: 'building', initTimestamp: tsAgo(NOW, AT_WARNING) },
+      ]
+      const report = computeEvalTimeReport(runs, NOW)
       expect(report.totalActive).toBe(2)
-      // Only the run at the threshold shows in entries
-      expect(report.entries).toHaveLength(1)
+      expect(report.entries).toHaveLength(1)  // only the one at/over threshold
     })
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,7 +9,11 @@ export interface RunListItem {
   triggeredBy?: string
   triggerReason?: string
   model?: string
-  runtime?: string
+  /** ISO timestamps from JSONL, preserved raw so callers can format live-ticking durations. */
+  initTimestamp?: string
+  inferStartTimestamp?: string
+  evalStartTimestamp?: string
+  endTimestamp?: string
 }
 
 const VALID_STATUSES = new Set([
@@ -49,6 +53,8 @@ interface JsonlRunItem {
   model_name?: string
   model_id?: string
   init_timestamp?: string
+  infer_start_timestamp?: string
+  eval_start_timestamp?: string
   end_timestamp?: string
 }
 
@@ -83,20 +89,16 @@ export async function fetchRunList(date: string): Promise<RunListItem[]> {
         } else if (item.model_id) {
           model = item.model_id
         }
-        // Calculate runtime from JSONL timestamps
-        let runtime: string | undefined
-        if (item.init_timestamp) {
-          const start = new Date(item.init_timestamp).getTime()
-          const end = item.end_timestamp ? new Date(item.end_timestamp).getTime() : Date.now()
-          runtime = formatDurationMs(end - start)
-        }
         items.push({
           slug,
           status: mapStatus(item.status),
           triggeredBy: item.triggered_by || undefined,
           triggerReason: item.trigger_reason || undefined,
           model,
-          runtime,
+          initTimestamp: item.init_timestamp || undefined,
+          inferStartTimestamp: item.infer_start_timestamp || undefined,
+          evalStartTimestamp: item.eval_start_timestamp || undefined,
+          endTimestamp: item.end_timestamp || undefined,
         })
       }
     } catch {
@@ -679,38 +681,50 @@ function stageLabelFor(status: RunListItemStatus): string {
   }
 }
 
+function parseIsoMs(ts: string | undefined): number | null {
+  if (!ts) return null
+  const ms = new Date(ts).getTime()
+  return isNaN(ms) ? null : ms
+}
+
 /** Return the timestamp (ms) at which the current stage started, or null. */
-function stageStartMs(metadata: RunMetadata, status: RunListItemStatus): number | null {
+function stageStartMsFromRun(run: RunListItem, status: RunListItemStatus): number | null {
   switch (status) {
-    case 'building': return getTimestampMs(metadata.params)
-    case 'pending': return getTimestampMs(metadata.init) ?? getTimestampMs(metadata.params)
-    case 'running-infer': return getTimestampMs(metadata.runInferStart)
-    case 'running-eval': return getTimestampMs(metadata.evalInferStart) ?? getTimestampMs(metadata.runInferEnd)
+    case 'building': return parseIsoMs(run.initTimestamp)
+    case 'pending': return parseIsoMs(run.initTimestamp)
+    case 'running-infer': return parseIsoMs(run.inferStartTimestamp)
+    case 'running-eval': return parseIsoMs(run.evalStartTimestamp) ?? parseIsoMs(run.inferStartTimestamp)
     default: return null
   }
 }
 
-/** Build an EvalTimeReport from all known run metadata.
+/** Build an EvalTimeReport from the JSONL-backed run list.
  *  Only non-finished runs are inspected; only entries exceeding the warning
  *  threshold appear in `entries`. */
 export function computeEvalTimeReport(
-  metadataMap: Record<string, RunMetadata>,
-  preStatuses: Record<string, RunListItemStatus>,
+  runs: RunListItem[],
   now: number = Date.now(),
 ): EvalTimeReport {
   const entries: EvalTimeEntry[] = []
   let totalActive = 0
 
-  for (const [slug, metadata] of Object.entries(metadataMap)) {
-    const status = preStatuses[slug] ?? getStageStatus(metadata)
+  for (const run of runs) {
+    const status = run.status
+    if (!status) continue
     if (status === 'completed' || status === 'error' || status === 'cancelled') continue
     totalActive++
 
-    const start = stageStartMs(metadata, status)
+    const start = stageStartMsFromRun(run, status)
     if (start === null) continue
     const elapsed = now - start
     if (elapsed >= EVAL_TIME_WARNING_MS) {
-      entries.push({ slug, status, elapsedMs: elapsed, stageLabel: stageLabelFor(status), triggeredBy: extractTriggeredBy(metadata) })
+      entries.push({
+        slug: run.slug,
+        status,
+        elapsedMs: elapsed,
+        stageLabel: stageLabelFor(status),
+        triggeredBy: run.triggeredBy || '—',
+      })
     }
   }
 

--- a/frontend/src/components/EvalTimeBadge.tsx
+++ b/frontend/src/components/EvalTimeBadge.tsx
@@ -1,35 +1,22 @@
 import { useMemo } from 'react'
 import { computeEvalTimeReport } from '../api'
-import type { RunMetadata, RunListItem, RunListItemStatus, EvalTimeReport } from '../api'
+import type { RunListItem, EvalTimeReport } from '../api'
 import { BadgePill, STATE_STYLES } from './ClusterHealth/primitives'
 import EvalTimeModal from './EvalTime/EvalTimeModal'
 
 interface Props {
-  runMetadataMap: Record<string, RunMetadata>
   runs: RunListItem[]
   isOpen?: boolean
   onToggle?: (open: boolean) => void
   onSelectRun?: (slug: string) => void
 }
 
-export default function EvalTimeBadge({ runMetadataMap, runs, isOpen, onToggle, onSelectRun }: Props) {
-  const report: EvalTimeReport = useMemo(() => {
-    // Build a preStatuses map from runs that already carry a status
-    const preStatuses: Record<string, RunListItemStatus> = {}
-    for (const run of runs) {
-      if (run.status) {
-        preStatuses[run.slug] = run.status
-      }
-    }
-    return computeEvalTimeReport(runMetadataMap, preStatuses)
-  }, [runMetadataMap, runs])
+export default function EvalTimeBadge({ runs, isOpen, onToggle, onSelectRun }: Props) {
+  const report: EvalTimeReport = useMemo(() => computeEvalTimeReport(runs), [runs])
 
   const open = isOpen ?? false
 
-  // Show pulsing placeholder only while the initial run list hasn't loaded yet.
-  // Once runs are available (even if runMetadataMap is empty because all runs
-  // had pre-parsed statuses), show the computed state.
-  if (runs.length === 0 && Object.keys(runMetadataMap).length === 0) {
+  if (runs.length === 0) {
     return <BadgePill dotClass="bg-oh-text-muted" dotPulse label="Eval Time" />
   }
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -135,7 +135,7 @@ export default function Header({ date, onDateChange, onRefresh, selectedRun, onB
           {/* Right: Cluster health + Refresh */}
           <div className="flex items-center gap-2">
             {!selectedRun && <ClusterHealthBadge refreshNonce={refreshNonce} isOpen={clusterHealthOpen} onToggle={onClusterHealthToggle} />}
-            {!selectedRun && <EvalTimeBadge runMetadataMap={runMetadataMap} runs={runs} isOpen={evalTimeOpen} onToggle={onEvalTimeToggle} onSelectRun={onSelectRun} />}
+            {!selectedRun && <EvalTimeBadge runs={runs} isOpen={evalTimeOpen} onToggle={onEvalTimeToggle} onSelectRun={onSelectRun} />}
             {!selectedRun && <ActiveWorkersBadge runMetadataMap={runMetadataMap} runs={runs} isOpen={activeWorkersOpen} onToggle={onActiveWorkersToggle} />}
           <button
             onClick={onRefresh}

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react'
 import type { RunMetadata, DayRunGroup, RunListItemStatus } from '../api'
-import { getStageStatus, getRuntime, isFinished, getActiveWorkersForInstance } from '../api'
+import { formatDurationMs, getActiveWorkersForInstance } from '../api'
 import ExportPathsModal from './ExportPathsModal'
 
 interface RunInfo {
@@ -11,7 +11,8 @@ interface RunInfo {
   status?: RunListItemStatus
   triggeredBy?: string
   triggerReason?: string
-  runtime?: string
+  initTimestamp?: string
+  endTimestamp?: string
 }
 
 interface RunListViewProps {
@@ -149,10 +150,10 @@ export default function RunListView({
   // Check if any run is non-finished to decide whether to tick the timer
   const hasNonFinished = useMemo(() => {
     return runs.some(run => {
-      const metadata = runMetadataMap[run.slug]
-      return metadata && !isFinished(metadata)
+      const s = run.status
+      return s !== 'completed' && s !== 'error' && s !== 'cancelled'
     })
-  }, [runs, runMetadataMap])
+  }, [runs])
 
   // Tick every 1s so elapsed time updates for non-finished runs
   useEffect(() => {
@@ -161,22 +162,26 @@ export default function RunListView({
     return () => clearInterval(interval)
   }, [hasNonFinished])
 
-  // Compute statuses and runtimes
-  // Status and runtime come from JSONL (pre-parsed), metadata only needed for additional details
+  // Compute statuses and runtimes from JSONL-backed timestamps so the value
+  // ticks every second for active runs (metadata is no longer loaded for the list view).
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
-      const metadata = runMetadataMap[run.slug]
-      // Use pre-parsed status from JSONL, only derive from metadata if needed
-      const status: StatusType = run.status || (metadata ? getStageStatus(metadata) : 'pending')
-      // Use pre-parsed runtime from JSONL if available, otherwise calculate from metadata
-      const runtime: string | null = run.runtime || (metadata ? getRuntime(metadata, now) : null)
-      const runFinished = metadata ? isFinished(metadata) : (run.status === 'completed' || run.status === 'error' || run.status === 'cancelled')
-      // triggeredBy and triggerReason come directly from JSONL (via RunListItem)
+      const status: StatusType = run.status || 'pending'
+      const runFinished = status === 'completed' || status === 'error' || status === 'cancelled'
+      let runtime: string | null = null
+      if (run.initTimestamp) {
+        const start = new Date(run.initTimestamp).getTime()
+        if (!isNaN(start)) {
+          const endStr = run.endTimestamp
+          const end = runFinished && endStr ? new Date(endStr).getTime() : now
+          if (!isNaN(end)) runtime = formatDurationMs(end - start)
+        }
+      }
       const triggeredBy = run.triggeredBy
       const triggerReason = run.triggerReason
       return { ...run, status, runtime, runFinished, triggeredBy, triggerReason }
     })
-  }, [runs, runMetadataMap, now])
+  }, [runs, now])
 
   const benchmarks = useMemo(() => [...new Set(runs.map(r => r.benchmark))].sort(), [runs])
   const statuses = useMemo(() => [...new Set(runsWithStatus.map(r => r.status))].sort(), [runsWithStatus])


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                

- List view stopped fetching per-run metadata, leaving the Runtime column as a stale snapshot and the Eval Time badge always "ok".                                                                                                     
- RunListItem now carries raw JSONL timestamps; RunListView formats runtime live against the existing 1 s ticker.
- computeEvalTimeReport now takes RunListItem[] instead of the (empty) metadata map, so slow/critical evals surface again.                                                                                                             
                                                                                                                                                                                                                                         
Fixes #168.  