### PR TITLE
Fix: Change cancel URL from OpenHands/evaluation to OpenHands/software-agent-sdk

### DIFF
--- a/frontend/src/__tests__/RunDetailView.test.tsx
+++ b/frontend/src/__tests__/RunDetailView.test.tsx
@@ -416,7 +416,7 @@ describe('RunDetailView', () => {
 
       expect(writeText).toHaveBeenCalledWith('123')
       expect(openSpy).toHaveBeenCalledWith(
-        'https://github.com/OpenHands/evaluation/actions/workflows/kill-eval-job.yml',
+        'https://github.com/OpenHands/software-agent-sdk/actions/workflows/cancel-eval.yml',
         '_blank'
       )
 

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -223,7 +223,7 @@ function renderWithUrl(text: string) {
   )
 }
 
-const KILL_WORKFLOW_URL = 'https://github.com/OpenHands/evaluation/actions/workflows/kill-eval-job.yml'
+const KILL_WORKFLOW_URL = 'https://github.com/OpenHands/software-agent-sdk/actions/workflows/cancel-eval.yml'
 
 function CancelEvaluationSection({ jobId }: { jobId: string }) {
   const handleClick = async () => {


### PR DESCRIPTION
## Summary

This PR fixes issue #170 by changing the cancel evaluation URL from `OpenHands/evaluation` to `OpenHands/software-agent-sdk`.

### Problem

Jobs are triggered from OpenHands/software-agent-sdk, but the cancel action was pointing to OpenHands/evaluation. This caused issues where users could trigger jobs but couldn't cancel them because they didn't have access to the evaluation repository's workflows.

### Solution

Changed the cancel button URL from:
- https://github.com/OpenHands/evaluation/actions/workflows/kill-eval-job.yml

To:
- https://github.com/OpenHands/software-agent-sdk/actions/workflows/cancel-eval.yml

This way, everybody who can create a job can also cancel it.

### Testing

- Updated the corresponding test in `RunDetailView.test.tsx` to verify the new URL
- All 56 tests in `RunDetailView.test.tsx` pass

### Checklist

- [x] Code compiles and runs
- [x] Tests pass

Closes #170

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c23d4db5-6a94-4703-b02a-2150996d429e)