### PR TITLE
Fix stale list-view status for in-progress runs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { fetchMultiDayRunList, fetchRunMetadata, parseRunSlug, getStageStatus } from './api'
+import { fetchMultiDayRunList, fetchRunMetadata, parseRunSlug, getStageStatus, isTerminalStatus } from './api'
 import type { RunMetadata, DayRunGroup, RunListItem } from './api'
 import RunListView from './components/RunListView'
 import RunDetailView from './components/RunDetailView'
@@ -133,13 +133,12 @@ export default function App() {
       const allRuns = groups.flatMap(g => g.runs)
       setRuns(allRuns)
       // JSONL lines for in-progress runs can go stale; re-derive from metadata.
-      const stale = allRuns.filter(r =>
-        !r.status || r.status === 'pending' || r.status === 'building'
-        || r.status === 'running-infer' || r.status === 'running-eval')
+      const stale = allRuns.filter(r => !isTerminalStatus(r.status))
       if (stale.length) {
         setLoadingMetadataList(true)
         Promise.all(stale.map(async r => [r.slug, await fetchRunMetadata(r.slug)] as const))
-          .then(entries => setRunMetadataMap(Object.fromEntries(entries)))
+          .then(entries => setRunMetadataMap(prev => ({ ...prev, ...Object.fromEntries(entries) })))
+          .catch(err => setError(err instanceof Error ? err.message : 'Failed to fetch run metadata'))
           .finally(() => setLoadingMetadataList(false))
       }
     } catch (err) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,12 +133,20 @@ export default function App() {
       const allRuns = groups.flatMap(g => g.runs)
       setRuns(allRuns)
       // JSONL lines for in-progress runs can go stale; re-derive from metadata.
+      // Use allSettled so a single fetch failure doesn't discard the other results.
       const stale = allRuns.filter(r => !isTerminalStatus(r.status))
       if (stale.length) {
         setLoadingMetadataList(true)
-        Promise.all(stale.map(async r => [r.slug, await fetchRunMetadata(r.slug)] as const))
-          .then(entries => setRunMetadataMap(prev => ({ ...prev, ...Object.fromEntries(entries) })))
-          .catch(err => setError(err instanceof Error ? err.message : 'Failed to fetch run metadata'))
+        Promise.allSettled(stale.map(async r => [r.slug, await fetchRunMetadata(r.slug)] as const))
+          .then(results => {
+            const entries = results
+              .filter((r): r is PromiseFulfilledResult<readonly [string, RunMetadata]> => r.status === 'fulfilled')
+              .map(r => r.value)
+            if (entries.length < stale.length) {
+              console.warn(`${stale.length - entries.length} metadata fetches failed`)
+            }
+            setRunMetadataMap(prev => ({ ...prev, ...Object.fromEntries(entries) }))
+          })
           .finally(() => setLoadingMetadataList(false))
       }
     } catch (err) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { fetchMultiDayRunList, fetchRunMetadata, parseRunSlug, getStageStatus, isTerminalStatus } from './api'
+import { fetchMultiDayRunList, fetchRunMetadata, fetchMetadataForSlugs, parseRunSlug, getStageStatus, isTerminalStatus } from './api'
 import type { RunMetadata, DayRunGroup, RunListItem } from './api'
 import RunListView from './components/RunListView'
 import RunDetailView from './components/RunDetailView'
@@ -133,20 +133,11 @@ export default function App() {
       const allRuns = groups.flatMap(g => g.runs)
       setRuns(allRuns)
       // JSONL lines for in-progress runs can go stale; re-derive from metadata.
-      // Use allSettled so a single fetch failure doesn't discard the other results.
       const stale = allRuns.filter(r => !isTerminalStatus(r.status))
       if (stale.length) {
         setLoadingMetadataList(true)
-        Promise.allSettled(stale.map(async r => [r.slug, await fetchRunMetadata(r.slug)] as const))
-          .then(results => {
-            const entries = results
-              .filter((r): r is PromiseFulfilledResult<readonly [string, RunMetadata]> => r.status === 'fulfilled')
-              .map(r => r.value)
-            if (entries.length < stale.length) {
-              console.warn(`${stale.length - entries.length} metadata fetches failed`)
-            }
-            setRunMetadataMap(prev => ({ ...prev, ...Object.fromEntries(entries) }))
-          })
+        fetchMetadataForSlugs(stale.map(r => r.slug))
+          .then(entries => setRunMetadataMap(prev => ({ ...prev, ...entries })))
           .finally(() => setLoadingMetadataList(false))
       }
     } catch (err) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,6 +132,16 @@ export default function App() {
       setDayGroups(groups)
       const allRuns = groups.flatMap(g => g.runs)
       setRuns(allRuns)
+      // JSONL lines for in-progress runs can go stale; re-derive from metadata.
+      const stale = allRuns.filter(r =>
+        !r.status || r.status === 'pending' || r.status === 'building'
+        || r.status === 'running-infer' || r.status === 'running-eval')
+      if (stale.length) {
+        setLoadingMetadataList(true)
+        Promise.all(stale.map(async r => [r.slug, await fetchRunMetadata(r.slug)] as const))
+          .then(entries => setRunMetadataMap(Object.fromEntries(entries)))
+          .finally(() => setLoadingMetadataList(false))
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load runs')
       setRuns([])
@@ -144,14 +154,6 @@ export default function App() {
   useEffect(() => {
     loadRuns()
   }, [loadRuns])
-
-  // When runs are loaded, no need to fetch metadata for list view anymore
-  // All data (status, triggeredBy, triggerReason) comes from JSONL
-  useEffect(() => {
-    if (runs.length > 0 && !selectedRun) {
-      setLoadingMetadataList(false)
-    }
-  }, [runs, selectedRun])
 
   // If we have a run from URL but haven't loaded its metadata yet, fetch it
   useEffect(() => {

--- a/frontend/src/__tests__/RunListView.test.tsx
+++ b/frontend/src/__tests__/RunListView.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import RunListView from '../components/RunListView'
 
 describe('RunListView', () => {
@@ -410,6 +410,88 @@ describe('RunListView', () => {
 
       // Should call setFilterStatus with 'all' to clear the filter
       expect(setFilterStatus).toHaveBeenCalledWith('all')
+    })
+  })
+
+  // Regression: issue #172. The JSONL line is written once at run start and
+  // never updated. A run whose JSONL status is still 'building' may actually
+  // be completed/cancelled/errored; metadata is the source of truth in that
+  // case and must override the stale JSONL status.
+  describe('metadata overrides stale non-terminal JSONL status', () => {
+    const terminalFromMetadata = (kind: 'completed' | 'error' | 'cancelled') => {
+      const base = {
+        init: null, params: null, error: null,
+        runInferStart: null, runInferEnd: null,
+        evalInferStart: null, evalInferEnd: null,
+        cancelEval: null,
+      }
+      if (kind === 'completed') return { ...base, evalInferEnd: { timestamp: '2025-01-01T00:00:00Z' } }
+      if (kind === 'error') return { ...base, error: { timestamp: '2025-01-01T00:00:00Z' } }
+      return { ...base, cancelEval: { timestamp: '2025-01-01T00:00:00Z' } }
+    }
+
+    // "Completed"/"Error"/etc. also appear in the status filter <option> list
+    // and in the per-status filter buttons in the summary bar. Scope the
+    // assertion to the row for the run under test.
+    const rowFor = (modelName: string) => screen.getByText(modelName).closest('tr')!
+
+    const makeProps = (runStatus: 'building' | 'running-infer' | 'running-eval' | 'pending', metadataKind: 'completed' | 'error' | 'cancelled') => ({
+      runs: [{ slug: 'swebench/model/1', benchmark: 'swebench', model: 'model', jobId: '1', status: runStatus }],
+      loading: false,
+      error: null,
+      onSelectRun: mockOnSelectRun,
+      runMetadataMap: { 'swebench/model/1': terminalFromMetadata(metadataKind) },
+      loadingMetadataList: false,
+      dayGroups: [{ date: '2025-01-01', runs: [{ slug: 'swebench/model/1' }] }],
+      filterBenchmark: 'all',
+      setFilterBenchmark: vi.fn(),
+      filterStatus: 'all',
+      setFilterStatus: vi.fn(),
+      filterText: '',
+      setFilterText: vi.fn(),
+      showDetail: false,
+    })
+
+    it('renders Completed when JSONL says building but metadata shows the run finished', () => {
+      render(<RunListView {...makeProps('building', 'completed')} />)
+      const row = within(rowFor('model'))
+      expect(row.getByText('Completed')).toBeInTheDocument()
+      expect(row.queryByText('Building')).not.toBeInTheDocument()
+    })
+
+    it('renders Cancelled when JSONL says running-eval but metadata shows cancelEval', () => {
+      render(<RunListView {...makeProps('running-eval', 'cancelled')} />)
+      const row = within(rowFor('model'))
+      expect(row.getByText('Cancelled')).toBeInTheDocument()
+      expect(row.queryByText('Eval')).not.toBeInTheDocument()
+    })
+
+    it('renders Error when JSONL says running-infer but metadata shows an error', () => {
+      render(<RunListView {...makeProps('running-infer', 'error')} />)
+      const row = within(rowFor('model'))
+      expect(row.getByText('Error')).toBeInTheDocument()
+      expect(row.queryByText('Inference')).not.toBeInTheDocument()
+    })
+
+    it('keeps the terminal JSONL status when metadata is missing (fast path)', () => {
+      const props = {
+        runs: [{ slug: 'swebench/model/1', benchmark: 'swebench', model: 'model', jobId: '1', status: 'completed' as const }],
+        loading: false,
+        error: null,
+        onSelectRun: mockOnSelectRun,
+        runMetadataMap: {},
+        loadingMetadataList: false,
+        dayGroups: [{ date: '2025-01-01', runs: [{ slug: 'swebench/model/1' }] }],
+        filterBenchmark: 'all',
+        setFilterBenchmark: vi.fn(),
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterText: '',
+        setFilterText: vi.fn(),
+        showDetail: false,
+      }
+      render(<RunListView {...props} />)
+      expect(within(rowFor('model')).getByText('Completed')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, getActiveWorkersForInstance, getPartialArchiveUrl, extractBenchmarkModelFromPartialArchiveUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl, fetchRunList, getClusterHealthState } from '../api'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, getActiveWorkersForInstance, getPartialArchiveUrl, extractBenchmarkModelFromPartialArchiveUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl, fetchRunList, getClusterHealthState, fetchMetadataForSlugs } from '../api'
 import type { RunMetadata, ClusterHealthReport } from '../api'
 
 function makeReport(overrides: Partial<ClusterHealthReport> = {}): ClusterHealthReport {
@@ -958,6 +958,49 @@ describe('getClusterHealthState', () => {
       summary: { healthy: false, issues: ['something we did not classify'], errors: [] },
     })
     expect(getClusterHealthState(report, FRESH_NOW)).toBe('warning')
+  })
+})
+
+describe('fetchMetadataForSlugs', () => {
+  const emptyMetadata = (): RunMetadata => ({
+    init: null, params: null, error: null,
+    runInferStart: null, runInferEnd: null,
+    evalInferStart: null, evalInferEnd: null,
+    cancelEval: null,
+  } as unknown as RunMetadata)
+
+  it('returns an empty object when given no slugs without calling fetchOne', async () => {
+    const fetchOne = vi.fn<(slug: string) => Promise<RunMetadata>>()
+    const result = await fetchMetadataForSlugs([], fetchOne)
+    expect(result).toEqual({})
+    expect(fetchOne).not.toHaveBeenCalled()
+  })
+
+  it('returns a slug->metadata map when all fetches succeed', async () => {
+    const a = emptyMetadata()
+    const b = emptyMetadata()
+    const fetchOne = vi.fn(async (slug: string) => (slug === 'a/x/1' ? a : b))
+    const result = await fetchMetadataForSlugs(['a/x/1', 'b/y/2'], fetchOne)
+    expect(result).toEqual({ 'a/x/1': a, 'b/y/2': b })
+  })
+
+  it('keeps successful results and warns when some fetches fail', async () => {
+    const ok = emptyMetadata()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fetchOne = vi.fn(async (slug: string) => {
+      if (slug === 'bad/y/2') throw new Error('boom')
+      return ok
+    })
+    const result = await fetchMetadataForSlugs(['good/x/1', 'bad/y/2', 'good/z/3'], fetchOne)
+    expect(result).toEqual({ 'good/x/1': ok, 'good/z/3': ok })
+    expect(warn).toHaveBeenCalledWith('1 metadata fetches failed')
+  })
+
+  it('does not reject when every fetch fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fetchOne = vi.fn(async () => { throw new Error('down') })
+    const result = await fetchMetadataForSlugs(['a/x/1', 'b/y/2'], fetchOne)
+    expect(result).toEqual({})
   })
 })
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -22,6 +22,10 @@ const VALID_STATUSES = new Set([
   'cancelled',
 ])
 
+export function isTerminalStatus(status: RunListItemStatus | undefined): boolean {
+  return status === 'completed' || status === 'error' || status === 'cancelled'
+}
+
 /** Map status from JSONL format to RunListItemStatus.
  *  Only returns a status if it's a known status value. */
 function mapStatus(status: string | undefined): RunListItemStatus | undefined {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -194,6 +194,25 @@ export async function fetchRunMetadata(runSlug: string): Promise<RunMetadata> {
   return metadata as unknown as RunMetadata
 }
 
+// Fetches metadata for each slug in parallel. Uses allSettled so one failed
+// fetch doesn't drop the results for the others.
+export async function fetchMetadataForSlugs(
+  slugs: string[],
+  fetchOne: (slug: string) => Promise<RunMetadata> = fetchRunMetadata,
+): Promise<Record<string, RunMetadata>> {
+  if (!slugs.length) return {}
+  const settled = await Promise.allSettled(
+    slugs.map(async slug => [slug, await fetchOne(slug)] as const),
+  )
+  const entries = settled
+    .filter((r): r is PromiseFulfilledResult<readonly [string, RunMetadata]> => r.status === 'fulfilled')
+    .map(r => r.value)
+  if (entries.length < slugs.length) {
+    console.warn(`${slugs.length - entries.length} metadata fetches failed`)
+  }
+  return Object.fromEntries(entries)
+}
+
 export function parseRunSlug(slug: string) {
   const parts = slug.replace(/\/$/, '').split('/')
   if (parts.length >= 3) {

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -176,7 +176,7 @@ export default function RunListView({
       }
       const runtime: string | null = run.runtime || (metadata ? getRuntime(metadata, now) : null)
       const runFinished = terminal || (metadata ? isFinished(metadata) : false)
-      return { ...run, status, runtime, runFinished, triggeredBy: run.triggeredBy, triggerReason: run.triggerReason }
+      return { ...run, status, runtime, runFinished }
     })
   }, [runs, runMetadataMap, now])
 

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react'
 import type { RunMetadata, DayRunGroup, RunListItemStatus } from '../api'
-import { getStageStatus, getRuntime, isFinished, getActiveWorkersForInstance } from '../api'
+import { getStageStatus, getRuntime, isFinished, getActiveWorkersForInstance, isTerminalStatus } from '../api'
 import ExportPathsModal from './ExportPathsModal'
 
 interface RunInfo {
@@ -165,10 +165,17 @@ export default function RunListView({
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
       const metadata = runMetadataMap[run.slug]
-      const isTerminal = run.status === 'completed' || run.status === 'error' || run.status === 'cancelled'
-      const status: StatusType = isTerminal ? run.status! : (metadata ? getStageStatus(metadata) : (run.status ?? 'pending'))
+      const terminal = isTerminalStatus(run.status)
+      let status: StatusType
+      if (terminal) {
+        status = run.status!
+      } else if (metadata) {
+        status = getStageStatus(metadata)
+      } else {
+        status = run.status ?? 'pending'
+      }
       const runtime: string | null = run.runtime || (metadata ? getRuntime(metadata, now) : null)
-      const runFinished = isTerminal || (metadata ? isFinished(metadata) : false)
+      const runFinished = terminal || (metadata ? isFinished(metadata) : false)
       return { ...run, status, runtime, runFinished, triggeredBy: run.triggeredBy, triggerReason: run.triggerReason }
     })
   }, [runs, runMetadataMap, now])

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -161,20 +161,15 @@ export default function RunListView({
     return () => clearInterval(interval)
   }, [hasNonFinished])
 
-  // Compute statuses and runtimes
-  // Status and runtime come from JSONL (pre-parsed), metadata only needed for additional details
+  // Terminal JSONL wins; non-terminal defers to metadata since the JSONL line can be stale.
   const runsWithStatus = useMemo(() => {
     return runs.map(run => {
       const metadata = runMetadataMap[run.slug]
-      // Use pre-parsed status from JSONL, only derive from metadata if needed
-      const status: StatusType = run.status || (metadata ? getStageStatus(metadata) : 'pending')
-      // Use pre-parsed runtime from JSONL if available, otherwise calculate from metadata
+      const isTerminal = run.status === 'completed' || run.status === 'error' || run.status === 'cancelled'
+      const status: StatusType = isTerminal ? run.status! : (metadata ? getStageStatus(metadata) : (run.status ?? 'pending'))
       const runtime: string | null = run.runtime || (metadata ? getRuntime(metadata, now) : null)
-      const runFinished = metadata ? isFinished(metadata) : (run.status === 'completed' || run.status === 'error' || run.status === 'cancelled')
-      // triggeredBy and triggerReason come directly from JSONL (via RunListItem)
-      const triggeredBy = run.triggeredBy
-      const triggerReason = run.triggerReason
-      return { ...run, status, runtime, runFinished, triggeredBy, triggerReason }
+      const runFinished = isTerminal || (metadata ? isFinished(metadata) : false)
+      return { ...run, status, runtime, runFinished, triggeredBy: run.triggeredBy, triggerReason: run.triggerReason }
     })
   }, [runs, runMetadataMap, now])
 


### PR DESCRIPTION
## Summary                                                                                                                                                                         
                  
- Closes #172. List view was stuck on stale statuses (`Building`, `Running-*`) for runs the detail view already showed as `completed`/`cancelled`/`error`.                         
- Root cause: the per-day JSONL writer writes a single line at run start (e.g. `"status": "init"`) and does not update it as the run progresses. The list reads JSONL only; the detail reads per-run metadata files — they disagree whenever a run finishes without a JSONL rewrite.                                                                               
- Frontend mitigation: for any list row whose JSONL status is non-terminal (`pending`/`building`/`running-infer`/`running-eval` or missing), fetch the run's metadata and let `getStageStatus` override the JSONL value. Terminal JSONL rows (`completed`/`error`/`cancelled`) stay on the fast path — no extra requests.                                        
                  
                                                                                                                                                                                     
- `frontend/src/App.tsx` — in `loadRuns`, after JSONL load, fire `fetchRunMetadata` in parallel for non-terminal rows and merge into `runMetadataMap`. Removes a now-wrong effect
  whose comment ("no need to fetch metadata anymore") is invalidated by this change.                                                                                                 
- `frontend/src/components/RunListView.tsx` — flip precedence in `runsWithStatus`: terminal JSONL wins, non-terminal defers to metadata. Same precedence for `runFinished`.
                                                                                                                                                                                     
 