### PR TITLE
fix: remove unused 'container' variable in test file

### DIFF
--- a/frontend/src/__tests__/ActiveWorkersBadge.test.tsx
+++ b/frontend/src/__tests__/ActiveWorkersBadge.test.tsx
@@ -48,7 +48,7 @@ describe('ActiveWorkersBadge', () => {
         createRun('swebench/qwen/123', 'juanmichelini', 'completed'),
         createRun('gaia/claude/456', 'admin', 'error'),
       ]
-      const { container } = render(
+      render(
         <ActiveWorkersBadge runMetadataMap={{}} runs={completedRuns} />
       )
       expect(screen.getByText('Active workers: 0')).toBeTruthy()


### PR DESCRIPTION
## Fix: Remove unused 'container' variable in test file

**Error:** `src/__tests__/ActiveWorkersBadge.test.tsx(51,13): error TS6133: 'container' is declared but its value is never read.`

**Root Cause:** The variable `container` was destructured from `render()` but never used in the test case `'shows zero workers when no runs are active'`.

**Fix:** Removed the unused `container` variable from the destructuring.

This was causing the TypeScript build to fail with strict mode enabled.

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e7ecd123-9ef1-47e6-ae05-2153a5f1830f)