### PR TITLE
Remove duplicate active workers in main view (fixes #175)

### DIFF
--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -119,7 +119,7 @@ export default function RunListView({
   setFilterStatus,
   filterText,
   setFilterText,
-  showDetail
+  showDetail: _showDetail
 }: RunListViewProps) {
   const showMultipleDays = dayGroups.length > 1
   const [isExportModalOpen, setIsExportModalOpen] = useState(false)

--- a/frontend/src/components/RunListView.tsx
+++ b/frontend/src/components/RunListView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react'
 import type { RunMetadata, DayRunGroup, RunListItemStatus } from '../api'
-import { getStageStatus, getRuntime, isFinished, getActiveWorkersForInstance } from '../api'
+import { getStageStatus, getRuntime, isFinished } from '../api'
 import ExportPathsModal from './ExportPathsModal'
 
 interface RunInfo {
@@ -220,27 +220,6 @@ export default function RunListView({
     return counts
   }, [runsWithStatus])
 
-  // Active workers count and per-author breakdown (from all runs, independent of filters)
-  // Only count runs in inference stage (running-infer)
-  const { totalActiveWorkers, activeWorkersByAuthor } = useMemo(() => {
-    let totalActiveWorkers = 0
-    const activeWorkersByAuthor: Record<string, number> = {}
-    // Only count runs in running-infer stage
-    const inferStatuses: StatusType[] = ['running-infer']
-    runsWithStatus.forEach(r => {
-      if (inferStatuses.includes(r.status)) {
-        const metadata = runMetadataMap[r.slug]
-        const workers = metadata ? getActiveWorkersForInstance(metadata) : 20
-        totalActiveWorkers += workers
-        const author = r.triggeredBy
-        if (author && author !== '—') {
-          activeWorkersByAuthor[author] = (activeWorkersByAuthor[author] || 0) + workers
-        }
-      }
-    })
-    return { totalActiveWorkers, activeWorkersByAuthor }
-  }, [runsWithStatus, runMetadataMap])
-
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -307,18 +286,6 @@ export default function RunListView({
               </button>
             ))}
           </div>
-          {!loadingMetadataList && !showDetail && totalActiveWorkers > 0 && (
-            <div className="flex items-center gap-3 flex-wrap text-xs">
-              <span className="text-oh-text-muted">
-                Active Workers: <span data-testid="total-active-workers" className={`font-bold ${totalActiveWorkers > 256 ? 'text-oh-error' : totalActiveWorkers >= 240 ? 'text-orange-400' : 'text-oh-primary'}`}>{totalActiveWorkers}</span>
-              </span>
-              {Object.entries(activeWorkersByAuthor).sort((a, b) => b[1] - a[1]).map(([author, count]) => (
-                <span key={author} data-testid={`active-workers-author-${author}`} className="text-oh-text-muted">
-                  <span className="font-medium text-oh-text">{author}</span>: {count}
-                </span>
-              ))}
-            </div>
-          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

This PR removes the duplicate active workers display from the main view (`RunListView.tsx`).

### Problem

The active workers count and per-author breakdown were being displayed in two places:
1. In the `ActiveWorkersBadge` component in the header (with a popup modal)
2. Directly in the `RunListView` main view section

### Solution

Removed the duplicate active workers calculation and display from `RunListView.tsx`. The `ActiveWorkersBadge` in the header (with its popup modal) is now the only place where this information is shown.

### Changes Made

- Removed the `getActiveWorkersForInstance` import from `RunListView.tsx`
- Removed the `useMemo` block that calculated `totalActiveWorkers` and `activeWorkersByAuthor`
- Removed the display block that showed active workers in the status counts section

The relevant tests in `RunListView.test.tsx` continue to pass.

Fixes #175

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/692e9490-c40a-4fa9-acd5-55680733699e)