### PR TITLE
fix: show proxy cost when client cost is zero (acp-codex)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -249,8 +249,16 @@ export interface CostReportSummary {
   sum_critic_files: number
 }
 
+export interface ProxyCostSummary {
+  total_proxy_cost: number
+  zero_proxy_cost_instances: number
+  only_main_output_proxy_cost: number
+  sum_critic_files_proxy_cost: number
+}
+
 export interface CostReport {
   summary: CostReportSummary | null
+  proxySummary: ProxyCostSummary | null
   fullUrl: string
 }
 
@@ -260,13 +268,15 @@ export async function fetchCostReport(slug: string): Promise<CostReport | null> 
   const v2Data = await fetchJson(`${BASE_URL}/${cleanSlug}/cost_report_v2.json`)
   if (v2Data) {
     const summary = (v2Data.summary as CostReportSummary) || null
-    return { summary, fullUrl: getResultsUrl(cleanSlug, 'cost_report_v2.json') }
+    const proxySummary = (v2Data.proxy_cost_summary as ProxyCostSummary) || null
+    return { summary, proxySummary, fullUrl: getResultsUrl(cleanSlug, 'cost_report_v2.json') }
   }
 
   const data = await fetchJson(`${BASE_URL}/${cleanSlug}/cost_report.jsonl`)
   if (!data) return null
   const summary = (data.summary as CostReportSummary) || null
-  return { summary, fullUrl: getResultsUrl(cleanSlug, 'cost_report.jsonl') }
+  const proxySummary = (data.proxy_cost_summary as ProxyCostSummary) || null
+  return { summary, proxySummary, fullUrl: getResultsUrl(cleanSlug, 'cost_report.jsonl') }
 }
 
 export function filterScalarFields(data: Record<string, unknown>): { scalarFields: Record<string, unknown>; hasListFields: boolean } {

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -62,7 +62,11 @@ function OutputReportCard({ report }: { report: OutputReport }) {
 
 function CostReportCard({ report }: { report: CostReport }) {
   const totalCost = report.summary?.total_cost
-  const showZeroCostWarning = typeof totalCost === 'number' && totalCost === 0
+  const proxyCost = report.proxySummary?.total_proxy_cost
+  const clientCostIsZero = typeof totalCost === 'number' && totalCost === 0
+  const hasProxyCost = typeof proxyCost === 'number' && proxyCost > 0
+  // Only warn if client cost is zero AND there's no proxy cost to fall back on
+  const showZeroCostWarning = clientCostIsZero && !hasProxyCost
 
   return (
     <div className="bg-oh-surface border border-oh-border rounded-lg p-4">
@@ -91,7 +95,37 @@ function CostReportCard({ report }: { report: CostReport }) {
         </div>
       )}
 
-      {report.summary ? (
+      {hasProxyCost && report.proxySummary && (
+        <div className="mb-3">
+          {clientCostIsZero && (
+            <p className="text-xs text-oh-text-muted mb-2 italic">
+              Client cost unavailable (acp-codex telemetry not wired) — showing proxy-reported cost.
+            </p>
+          )}
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <tbody>
+                {Object.entries(report.proxySummary).map(([key, value]) => (
+                  <tr key={key} className="border-b border-oh-border/50 last:border-0">
+                    <td className="py-1.5 pr-4 text-oh-text-muted font-mono text-xs whitespace-nowrap align-top">
+                      {key}
+                    </td>
+                    <td className="py-1.5 text-oh-text font-mono text-xs break-all">
+                      {typeof value === 'number'
+                        ? key.includes('cost')
+                          ? `$${value.toFixed(4)}`
+                          : String(value)
+                        : String(value ?? '—')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {report.summary && !clientCostIsZero ? (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <tbody>
@@ -114,9 +148,9 @@ function CostReportCard({ report }: { report: CostReport }) {
             </tbody>
           </table>
         </div>
-      ) : (
+      ) : !hasProxyCost ? (
         <p className="text-xs text-oh-text-muted italic">No summary available</p>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -60,6 +60,11 @@ function OutputReportCard({ report }: { report: OutputReport }) {
   )
 }
 
+function formatProxyCostValue(key: string, value: unknown): string {
+  if (typeof value !== 'number') return String(value ?? '—')
+  return key.includes('cost') ? `$${value.toFixed(4)}` : String(value)
+}
+
 function CostReportCard({ report }: { report: CostReport }) {
   const totalCost = report.summary?.total_cost
   const proxyCost = report.proxySummary?.total_proxy_cost
@@ -95,13 +100,11 @@ function CostReportCard({ report }: { report: CostReport }) {
         </div>
       )}
 
-      {hasProxyCost && report.proxySummary && (
+      {hasProxyCost && clientCostIsZero && report.proxySummary && (
         <div className="mb-3">
-          {clientCostIsZero && (
-            <p className="text-xs text-oh-text-muted mb-2 italic">
-              Client cost unavailable (acp-codex telemetry not wired) — showing proxy-reported cost.
-            </p>
-          )}
+          <p className="text-xs text-oh-text-muted mb-2 italic">
+            Client cost unavailable (acp-codex telemetry not wired) — showing proxy-reported cost.
+          </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <tbody>
@@ -111,11 +114,7 @@ function CostReportCard({ report }: { report: CostReport }) {
                       {key}
                     </td>
                     <td className="py-1.5 text-oh-text font-mono text-xs break-all">
-                      {typeof value === 'number'
-                        ? key.includes('cost')
-                          ? `$${value.toFixed(4)}`
-                          : String(value)
-                        : String(value ?? '—')}
+                      {formatProxyCostValue(key, value)}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Problem

acp-codex runs always report `accumulated_cost: 0` in trajectories ([AGE-1023](https://linear.app/all-hands-ai/issue/AGE-1023/acp-codex-cost-and-token-telemetry-is-completely-zero)), so `cost_report.jsonl` has `summary.total_cost = $0`. The monitor shows a ⚠️ warning and the zero table — unhelpful because the **proxy cost IS tracked** in `proxy_cost_summary` (e.g. swtbench gpt-5.5: $478.98, swebenchmultimodal gpt-5.5: $192.22) but was never read.

## Fix

**`api.ts`**
- Add `ProxyCostSummary` interface mirroring the `proxy_cost_summary` field in `cost_report.jsonl`
- Add `proxySummary` field to `CostReport`
- Read `data.proxy_cost_summary` in `fetchCostReport` for both `cost_report.jsonl` and `cost_report_v2.json`

**`CompletedRunResults.tsx`**
- When client cost is zero but proxy cost is available: show the `proxy_cost_summary` table with a short explanatory note ("Client cost unavailable (acp-codex telemetry not wired) — showing proxy-reported cost") and suppress the ⚠️ warning
- When both are zero/missing: keep the existing ⚠️ warning
- When client cost is non-zero: show the existing `summary` table as before (proxy cost hidden to avoid duplication)

## Before / After

**Before** (swtbench gpt-5.5):
```
⚠️ Cost is $0.0000
Check if cost was added to infra. Token usage was tracked, you can recalculate costs.
total_cost    $0.0000
total_duration    63054.9s
...
```

**After**:
```
Client cost unavailable (acp-codex telemetry not wired) — showing proxy-reported cost.
total_proxy_cost              $478.9755
zero_proxy_cost_instances     0
only_main_output_proxy_cost   $478.9755
sum_critic_files_proxy_cost   $478.9755
```