### PR TITLE
Add Laminar traces button under Run Inference (fixes #181)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,12 @@ cd frontend && npm run lint   # run eslint
 - `frontend/src/components/ExportPathsModal.tsx` can export both results-bucket file URLs and an `eval_monitor_url` detail-page link for each run.
 - `eval_monitor_url` is built from the current monitor URL, preserves existing query params like date/days/filters, and clears any hash before adding `run=<slug>`.
 
+## Laminar Traces Button
+- `frontend/src/components/StatusTimeline.tsx` renders a "🔍 Laminar traces" button under the **Run Inference** stage of the Pipeline Progress section.
+- The button is shown only after inference has started (`runInferStart` metadata file exists) and when `params.unique_eval_name` is available.
+- The URL points to `https://laminar.sh/project/<VITE_LAMINAR_PROJECT_ID>/traces?search=<unique_eval_name>&startDate=<infer_start_timestamp>`, so the trace view is filtered to this run and anchored at the beginning of inference.
+- Set the `VITE_LAMINAR_PROJECT_ID` build-time env var (e.g. in Vercel) to the Laminar project that ingests benchmark traces. If unset, the button is hidden.
+
 ## Coding Style
 - TypeScript strict mode, React functional components with hooks
 - Tailwind CSS for styling with custom `oh-*` color theme (defined in `tailwind.config.js`)

--- a/frontend/src/__tests__/StatusTimeline.test.tsx
+++ b/frontend/src/__tests__/StatusTimeline.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { render } from '@testing-library/react'
-import StatusTimeline, { formatStageDuration } from '../components/StatusTimeline'
+import StatusTimeline, { formatStageDuration, buildLaminarTracesUrl } from '../components/StatusTimeline'
 import type { RunMetadata } from '../api'
 
 function makeMetadata(overrides: Partial<RunMetadata> = {}): RunMetadata {
@@ -53,6 +53,16 @@ describe('formatStageDuration', () => {
 })
 
 describe('StatusTimeline', () => {
+  // Stub a project id so that the Laminar-button-related tests can rely on
+  // a deterministic URL. Tests that explicitly need a missing project id
+  // use the `buildLaminarTracesUrl` helper directly.
+  beforeAll(() => {
+    vi.stubEnv('VITE_LAMINAR_PROJECT_ID', 'test-project')
+  })
+  afterAll(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('shows duration instead of timestamp for completed stages', () => {
     const metadata = makeMetadata({
       params: { timestamp: '2025-03-15T10:00:00Z' },
@@ -127,5 +137,82 @@ describe('StatusTimeline', () => {
     const text = container.textContent!
     expect(text).not.toContain('UTC')
     expect(text).not.toMatch(/\d{2}:\d{2}:\d{2}/)
+  })
+
+  it('renders a Laminar traces button under Run Inference once inference has started', () => {
+    const metadata = makeMetadata({
+      params: {
+        timestamp: '2025-03-15T10:00:00Z',
+        unique_eval_name: '26779733963-gemini-3-5',
+      },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:06:00Z' },
+    })
+    const { queryByTestId } = render(
+      <StatusTimeline metadata={metadata} now={Date.now()} />,
+    )
+    const button = queryByTestId('laminar-traces-button') as HTMLAnchorElement | null
+    expect(button).not.toBeNull()
+    expect(button!.href).toContain('https://laminar.sh/project/test-project/traces')
+    expect(button!.href).toContain('search=26779733963-gemini-3-5')
+    // Time-anchored from the beginning of inference
+    expect(button!.href).toContain('startDate=')
+    expect(decodeURIComponent(button!.href)).toContain('2025-03-15T10:06:00Z')
+  })
+
+  it('does not render Laminar button before inference starts', () => {
+    const metadata = makeMetadata({
+      params: {
+        timestamp: '2025-03-15T10:00:00Z',
+        unique_eval_name: '26779733963-gemini-3-5',
+      },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+    })
+    const { queryByTestId } = render(
+      <StatusTimeline metadata={metadata} now={Date.now()} />,
+    )
+    expect(queryByTestId('laminar-traces-button')).toBeNull()
+  })
+
+  it('does not render Laminar button when unique_eval_name is missing', () => {
+    const metadata = makeMetadata({
+      params: { timestamp: '2025-03-15T10:00:00Z' },
+      init: { timestamp: '2025-03-15T10:05:00Z' },
+      runInferStart: { timestamp: '2025-03-15T10:06:00Z' },
+    })
+    const { queryByTestId } = render(
+      <StatusTimeline metadata={metadata} now={Date.now()} />,
+    )
+    expect(queryByTestId('laminar-traces-button')).toBeNull()
+  })
+})
+
+describe('buildLaminarTracesUrl', () => {
+  it('returns null when no project ID is configured', () => {
+    expect(buildLaminarTracesUrl('some-name', '2025-03-15T10:00:00Z', '')).toBeNull()
+  })
+
+  it('returns null when no unique_eval_name is provided', () => {
+    expect(buildLaminarTracesUrl(null, '2025-03-15T10:00:00Z', 'proj-1')).toBeNull()
+    expect(buildLaminarTracesUrl(undefined, '2025-03-15T10:00:00Z', 'proj-1')).toBeNull()
+  })
+
+  it('builds a URL filtered by unique_eval_name and infer start time', () => {
+    const url = buildLaminarTracesUrl(
+      '26779733963-gemini-3-5',
+      '2025-03-15T10:06:00Z',
+      'proj-1',
+    )
+    expect(url).not.toBeNull()
+    expect(url).toContain('https://laminar.sh/project/proj-1/traces')
+    expect(url).toContain('search=26779733963-gemini-3-5')
+    expect(decodeURIComponent(url!)).toContain('startDate=2025-03-15T10:06:00Z')
+  })
+
+  it('omits startDate when no inferStartTimestamp is provided', () => {
+    const url = buildLaminarTracesUrl('eval-1', null, 'proj-1')
+    expect(url).not.toBeNull()
+    expect(url).toContain('search=eval-1')
+    expect(url).not.toContain('startDate')
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -142,9 +142,13 @@ export async function fetchMultiDayRunList(baseDate: string, numDays: number): P
   return results
 }
 
+export interface RunParams extends Record<string, unknown> {
+  unique_eval_name?: string
+}
+
 export interface RunMetadata {
   init: Record<string, unknown> | null
-  params: Record<string, unknown> | null
+  params: RunParams | null
   error: Record<string, unknown> | null
   runInferStart: Record<string, unknown> | null
   runInferEnd: Record<string, unknown> | null

--- a/frontend/src/components/StatusTimeline.tsx
+++ b/frontend/src/components/StatusTimeline.tsx
@@ -43,6 +43,17 @@ function getTimestamp(data: Record<string, unknown> | null): string | null {
  * but uses the project traces view so that traces are visible while the run
  * is still in progress (the shared evals URL needs an eval_id that only
  * becomes available after inference completes).
+ *
+ * @param uniqueEvalName  The run's unique_eval_name (used as the Laminar
+ *   trace search filter). If null/undefined/empty, returns null.
+ * @param inferStartTimestamp  ISO 8601 timestamp of the start of inference.
+ *   If provided, it's passed as the `startDate` query param to anchor the
+ *   trace view. If omitted, the URL is still returned without it.
+ * @param projectId  Optional explicit Laminar project ID. Two semantics:
+ *   - `undefined` (default): read `VITE_LAMINAR_PROJECT_ID` at call time.
+ *   - explicit string (including `''`): use this value verbatim. An empty
+ *     string is treated as "no project configured" and returns null. Tests
+ *     use this to exercise the no-project-id path without mutating env.
  */
 export function buildLaminarTracesUrl(
   uniqueEvalName: string | null | undefined,
@@ -83,7 +94,7 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
   const hasError = !!metadata.error
   const [currentTime, setCurrentTime] = useState(nowProp ?? Date.now())
 
-  const uniqueEvalName = (metadata.params?.unique_eval_name as string | undefined) ?? null
+  const uniqueEvalName = metadata.params?.unique_eval_name ?? null
   const inferStartTs = getTimestamp(metadata.runInferStart)
   const laminarUrl = metadata.runInferStart
     ? buildLaminarTracesUrl(uniqueEvalName, inferStartTs)
@@ -154,6 +165,9 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
                   <p className={`text-[10px] ${durationColor} mt-0.5`}>{durationText}</p>
                 )}
                 {showLaminarButton && (
+                  // laminarUrl is guaranteed non-null here: showLaminarButton
+                  // is true only when !!laminarUrl. The non-null assertion is
+                  // needed because TS can't narrow through the boolean.
                   <a
                     href={laminarUrl!}
                     target="_blank"

--- a/frontend/src/components/StatusTimeline.tsx
+++ b/frontend/src/components/StatusTimeline.tsx
@@ -20,9 +20,45 @@ const STAGES: Stage[] = [
   { label: 'Run Evaluation', startKey: 'evalInferStart', endKey: 'evalInferEnd' },
 ]
 
+// Laminar project ID used to build trace URLs.
+// Configurable at build time via the VITE_LAMINAR_PROJECT_ID env var so that
+// the deployment (e.g. Vercel) can point at the correct Laminar project
+// without hard-coding it in the repo. Read lazily so that tests can stub it.
+function getLaminarProjectId(): string {
+  return (import.meta.env?.VITE_LAMINAR_PROJECT_ID as string | undefined) || ''
+}
+
 function getTimestamp(data: Record<string, unknown> | null): string | null {
   if (!data) return null
   return (data.timestamp as string) || null
+}
+
+/**
+ * Build a Laminar traces URL filtered by the run's unique_eval_name and
+ * starting at the beginning of inference. Returns null if we don't have
+ * enough information (no project ID configured or no eval name available).
+ *
+ * Mirrors the laminar link added by the push-to-index workflow
+ * (https://github.com/OpenHands/evaluation/actions/workflows/push-to-index.yml)
+ * but uses the project traces view so that traces are visible while the run
+ * is still in progress (the shared evals URL needs an eval_id that only
+ * becomes available after inference completes).
+ */
+export function buildLaminarTracesUrl(
+  uniqueEvalName: string | null | undefined,
+  inferStartTimestamp: string | null | undefined,
+  projectId?: string,
+): string | null {
+  const pid = projectId !== undefined ? projectId : getLaminarProjectId()
+  if (!pid || !uniqueEvalName) return null
+  const params = new URLSearchParams()
+  params.set('search', uniqueEvalName)
+  if (inferStartTimestamp) {
+    // Laminar's traces view accepts a startDate query param (ISO 8601) to
+    // anchor the time window at the beginning of inference.
+    params.set('startDate', inferStartTimestamp)
+  }
+  return `https://laminar.sh/project/${pid}/traces?${params.toString()}`
 }
 
 export function formatStageDuration(startStr: string | null, endStr: string | null, isActive: boolean, now: number): string {
@@ -46,6 +82,12 @@ export function formatStageDuration(startStr: string | null, endStr: string | nu
 export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelineProps) {
   const hasError = !!metadata.error
   const [currentTime, setCurrentTime] = useState(nowProp ?? Date.now())
+
+  const uniqueEvalName = (metadata.params?.unique_eval_name as string | undefined) ?? null
+  const inferStartTs = getTimestamp(metadata.runInferStart)
+  const laminarUrl = metadata.runInferStart
+    ? buildLaminarTracesUrl(uniqueEvalName, inferStartTs)
+    : null
 
   useEffect(() => {
     if (nowProp !== undefined) {
@@ -100,6 +142,9 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
 
           const durationColor = isCompleted ? 'text-oh-success' : isActive ? 'text-oh-primary' : 'text-oh-text-muted'
 
+          const showLaminarButton =
+            stage.label === 'Run Inference' && !!laminarUrl
+
           return (
             <div key={stage.label} className="flex items-center flex-1">
               <div className="flex flex-col items-center">
@@ -107,6 +152,18 @@ export default function StatusTimeline({ metadata, now: nowProp }: StatusTimelin
                 <p className="text-xs font-medium text-oh-text mt-2 whitespace-nowrap">{stage.label}</p>
                 {durationText && (
                   <p className={`text-[10px] ${durationColor} mt-0.5`}>{durationText}</p>
+                )}
+                {showLaminarButton && (
+                  <a
+                    href={laminarUrl!}
+                    target="_blank"
+                    rel="noreferrer"
+                    data-testid="laminar-traces-button"
+                    title="View Laminar traces from the beginning of inference"
+                    className="mt-1.5 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-oh-primary/10 text-oh-primary border border-oh-primary/30 hover:bg-oh-primary/20 transition-colors whitespace-nowrap"
+                  >
+                    🔍 Laminar traces
+                  </a>
                 )}
               </div>
               {i < STAGES.length - 1 && (


### PR DESCRIPTION
## Summary

Adds a **🔍 Laminar traces** button under the **Run Inference** stage of the Pipeline Progress section, similar to how the [`push-to-index.yml`](https://github.com/OpenHands/evaluation/actions/workflows/push-to-index.yml) workflow attaches a Laminar link to its scoreboard entry. Fixes #181.

## Changes

- **`frontend/src/components/StatusTimeline.tsx`**
  - New `buildLaminarTracesUrl(uniqueEvalName, inferStartTimestamp, projectId?)` helper that constructs a Laminar project traces URL filtered by `unique_eval_name` and anchored at the inference start time via `startDate`.
  - In `StatusTimeline`, render a small "🔍 Laminar traces" pill below the `Run Inference` stage label when:
    1. `runInferStart` metadata exists (inference has started), and
    2. `params.unique_eval_name` is available, and
    3. `VITE_LAMINAR_PROJECT_ID` is configured.
  - The button is hidden when any of those are missing, so existing deployments without the env var keep working unchanged.
- **`frontend/src/__tests__/StatusTimeline.test.tsx`**
  - Unit tests for `buildLaminarTracesUrl` covering missing project ID, missing eval name, full URL build, and the `startDate` fallback.
  - Component tests asserting the button renders only after inference starts and only when a `unique_eval_name` is present, and that the rendered URL contains the expected `search` and `startDate` query parameters.
- **`AGENTS.md`** — documents the new button, its visibility rules, and the `VITE_LAMINAR_PROJECT_ID` build-time env var.

## Why this URL shape?

The push-to-index workflow uses `https://laminar.sh/shared/evals/{eval_id}`, but `eval_id` is only stored inside `output.jsonl` (bundled into `results.tar.gz`) and isn't available client-side during a live run. Using the project traces view filtered by `unique_eval_name` lets users open Laminar **from the beginning of inference** — i.e. while the run is still in flight — which is what the issue asks for.

## How to deploy

Set `VITE_LAMINAR_PROJECT_ID` to the OpenHands benchmark Laminar project ID in the Vercel project settings (and locally in `frontend/.env.local` for development). With no value set, the button is simply hidden.

## Tests

```bash
cd frontend && npx vitest run StatusTimeline
# 20 tests passed (incl. 7 new ones for the Laminar button)
```

The frontend also builds (`npx vite build`) and typechecks (`npx tsc --noEmit`) cleanly.

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/945e8b6c-3eec-4a21-96d2-720a3e907e76)