### PR TITLE
Fix resumed-run badge linking back to the current run instead of the original

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, getActiveWorkersForInstance, getPartialArchiveUrl, extractBenchmarkModelFromPartialArchiveUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl, fetchRunList, getClusterHealthState } from '../api'
+import { getResultsUrl, filterScalarFields, extractTriggeredBy, extractTriggerReason, getDateNDaysAgo, getDatesForRange, fetchSubmissionData, fetchCostReport, getActiveWorkersForInstance, getPartialArchiveUrl, extractBenchmarkModelFromPartialArchiveUrl, extractTimestampFromPartialArchiveUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl, fetchRunList, getClusterHealthState } from '../api'
 import type { RunMetadata, ClusterHealthReport } from '../api'
 
 function makeReport(overrides: Partial<ClusterHealthReport> = {}): ClusterHealthReport {
@@ -649,11 +649,24 @@ describe('getOriginalRunSlug', () => {
     expect(getOriginalRunSlug(metadata, 'swtbench/litellm_proxy-minimax-MiniMax-M2-7/24039895569')).toBe('swtbench/litellm_proxy-minimax-MiniMax-M2-7/23324404309')
   })
 
-  it('uses github_run_id when it looks like a timestamp', () => {
+  it('extracts original timestamp from partial_archive_url when only that is available', () => {
+    // This matches the real-world case from issue #183 where the resumed run
+    // only has partial_archive_url set (no original_run_id / original_timestamp).
+    // The current run's github_run_id must NOT be used as the original timestamp.
     const metadata = makeMetadata({
       params: {
-        github_run_id: '23324404309',
-        partial_archive_url: 'swtbench/litellm_proxy-minimax-MiniMax-M2-7/24039895569/results.tar.gz',
+        github_run_id: '27052081405',
+        partial_archive_url: 'https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-gemini-3-5-flash/26986568857/infer-output.tar.gz',
+      },
+    })
+    expect(getOriginalRunSlug(metadata, 'swebenchmultimodal/litellm_proxy-gemini-3-5-flash/27052081405')).toBe('swebenchmultimodal/litellm_proxy-gemini-3-5-flash/26986568857')
+  })
+
+  it('prefers the partial_archive_url timestamp over the current run github_run_id', () => {
+    const metadata = makeMetadata({
+      params: {
+        github_run_id: '99999999999',
+        partial_archive_url: 'swtbench/litellm_proxy-minimax-MiniMax-M2-7/23324404309/results.tar.gz',
       },
     })
     expect(getOriginalRunSlug(metadata, 'swtbench/litellm_proxy-minimax-MiniMax-M2-7/24039895569')).toBe('swtbench/litellm_proxy-minimax-MiniMax-M2-7/23324404309')
@@ -706,6 +719,51 @@ describe('buildOriginalRunUrl', () => {
   it('sets text filter to timestamp', () => {
     const result = buildOriginalRunUrl('https://example.com/', 'swtbench/model/789')
     expect(result).toContain('text=789')
+  })
+
+  it('preserves existing query params from the current URL (e.g. days, date)', () => {
+    const result = buildOriginalRunUrl(
+      'https://example.com/?days=15&date=2025-01-02&run=current/run/27052081405',
+      'swebenchmultimodal/litellm_proxy-gemini-3-5-flash/26986568857',
+    )
+    expect(result).toContain('days=15')
+    expect(result).toContain('date=2025-01-02')
+    expect(result).toContain('run=swebenchmultimodal%2Flitellm_proxy-gemini-3-5-flash%2F26986568857')
+    expect(result).toContain('text=26986568857')
+  })
+
+  it('falls back gracefully when the current URL is unparseable', () => {
+    const result = buildOriginalRunUrl('not a url', 'swtbench/model/789')
+    expect(result).toContain('run=swtbench%2Fmodel%2F789')
+    expect(result).toContain('text=789')
+  })
+})
+
+describe('extractTimestampFromPartialArchiveUrl', () => {
+  it('returns null for null/undefined/empty', () => {
+    expect(extractTimestampFromPartialArchiveUrl(null)).toBeNull()
+    expect(extractTimestampFromPartialArchiveUrl(undefined)).toBeNull()
+    expect(extractTimestampFromPartialArchiveUrl('')).toBeNull()
+  })
+
+  it('extracts the timestamp segment after benchmark/model', () => {
+    expect(
+      extractTimestampFromPartialArchiveUrl(
+        'swebenchmultimodal/litellm_proxy-gemini-3-5-flash/26986568857/infer-output.tar.gz',
+      ),
+    ).toBe('26986568857')
+  })
+
+  it('extracts the timestamp from a results.tar.gz path', () => {
+    expect(
+      extractTimestampFromPartialArchiveUrl(
+        'swtbench/litellm_proxy-minimax-MiniMax-M2-7/24039895569/results.tar.gz',
+      ),
+    ).toBe('24039895569')
+  })
+
+  it('returns null when there is no timestamp segment', () => {
+    expect(extractTimestampFromPartialArchiveUrl('invalid-url')).toBeNull()
   })
 })
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -466,6 +466,21 @@ export function extractBenchmarkModelFromPartialArchiveUrl(partialArchiveUrl: st
   return match[1]
 }
 
+/** Extract the original run's timestamp (run id) from a partial_archive_url.
+ *  For example:
+ *  Input: "swebenchmultimodal/litellm_proxy-gemini-3-5-flash/26986568857/infer-output.tar.gz"
+ *  Output: "26986568857"
+ */
+export function extractTimestampFromPartialArchiveUrl(partialArchiveUrl: string | null | undefined): string | null {
+  if (!partialArchiveUrl || typeof partialArchiveUrl !== 'string') return null
+
+  // Pattern to match: benchmark/model/timestamp/anything
+  const match = partialArchiveUrl.match(/^.+?\/(\d+)\//)
+  if (!match) return null
+
+  return match[1]
+}
+
 /** Check if a run is a resumed run by looking for partial_archive_url in params.
  *  A resumed run has a partial_archive_url that points to another run's results.
  */
@@ -504,13 +519,15 @@ export function getOriginalRunSlug(metadata: RunMetadata | null, _currentSlug: s
   if (typeof originalTimestamp === 'string' && originalTimestamp) {
     return `${benchmarkModel}/${originalTimestamp}`
   }
-  
-  // Try to get timestamp from params.github_run_id if it's actually a timestamp
-  const githubRunId = metadata.params.github_run_id
-  if (typeof githubRunId === 'string' && githubRunId && /^\d+$/.test(githubRunId)) {
-    return `${benchmarkModel}/${githubRunId}`
+
+  // Otherwise, extract the timestamp directly from the partial_archive_url itself.
+  // The URL has the form benchmark/model/<original-timestamp>/<file>, so the path
+  // segment after benchmark/model is the original run's id.
+  const archiveTimestamp = extractTimestampFromPartialArchiveUrl(partialArchiveUrl)
+  if (archiveTimestamp) {
+    return `${benchmarkModel}/${archiveTimestamp}`
   }
-  
+
   return null
 }
 
@@ -738,15 +755,24 @@ export function computeEvalTimeReport(
   return { entries, totalActive, state }
 }
 
-export function buildOriginalRunUrl(_currentUrl: string, originalRunSlug: string): string {
+export function buildOriginalRunUrl(currentUrl: string, originalRunSlug: string): string {
   // Extract the original timestamp from the slug (last part after the last /)
   const parts = originalRunSlug.split('/')
   const originalTimestamp = parts[parts.length - 1]
-  
+
   // Build the monitor URL directly using the current host
   // This avoids issues when window.location.href points to a different domain (e.g., results bucket)
   const baseUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
-  const params = new URLSearchParams()
+
+  // Preserve existing query params from the current URL (e.g. days, date, filters)
+  // so the original run page opens with the same filter context.
+  let params: URLSearchParams
+  try {
+    params = new URL(currentUrl).searchParams
+  } catch {
+    params = new URLSearchParams()
+  }
+
   params.set('run', originalRunSlug)
   if (originalTimestamp) {
     params.set('text', originalTimestamp)


### PR DESCRIPTION
Fixes #183.

## Problem

On a resumed run's detail page (e.g. `?run=swebenchmultimodal/litellm_proxy-gemini-3-5-flash/27052081405/`), the **🔄 Resumed run** badge linked back to the **current** run instead of the run being resumed:

- Actual: `?run=swebenchmultimodal/litellm_proxy-gemini-3-5-flash/27052081405&text=27052081405` (same run!)
- Expected: `?run=swebenchmultimodal/litellm_proxy-gemini-3-5-flash/26986568857/&days=15&text=26986568857` (the run whose `results.tar.gz` we resumed from)

## Root cause

Two issues in `frontend/src/api.ts`:

1. **`getOriginalRunSlug`** fell back to `params.github_run_id` when neither `original_run_id` nor `original_timestamp` were present. But `github_run_id` identifies the **current** run, not the original. The correct source for the original timestamp is the `partial_archive_url` itself, whose path has the form `benchmark/model/<original-timestamp>/<file>` (e.g. `.../26986568857/infer-output.tar.gz`).

2. **`buildOriginalRunUrl`** ignored the current URL's query string, so contextual filters like `days=15` were dropped when navigating to the original run.

## Fix

- Added `extractTimestampFromPartialArchiveUrl()` helper that pulls the timestamp segment out of the partial-archive path.
- `getOriginalRunSlug()` now uses this helper as the fallback instead of the (wrong) current-run `github_run_id`.
- `buildOriginalRunUrl()` now preserves query params from the current URL (e.g. `days`, `date`, filters) before adding `run` and `text`.

## Tests

- Replaced the obsolete `'uses github_run_id when it looks like a timestamp'` test with two new cases that match real-world metadata (including the exact slugs from the issue).
- Added `extractTimestampFromPartialArchiveUrl` unit tests.
- Added a `buildOriginalRunUrl` test that asserts existing query params (`days`, `date`) are preserved.

All 16 resume-related tests pass, and `npm run build` (tsc + vite) succeeds.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c8d3fccc-ea72-422a-a9cb-c535cb41b8cd)