### PR TITLE
feat(cost-report): surface cache_hit_rate with missing/zero warnings

### DIFF
--- a/frontend/src/__tests__/CompletedRunResults.test.tsx
+++ b/frontend/src/__tests__/CompletedRunResults.test.tsx
@@ -4,7 +4,13 @@ import CompletedRunResults from '../components/CompletedRunResults'
 
 const originalFetch = globalThis.fetch
 
-function mockFetchWithCost(totalCost: number) {
+// Anchors used by the cache-hit-rate "missing" warning logic
+// (Date.UTC month is 0-indexed: 5 = June).
+const CACHE_HIT_RATE_CUTOFF_MS = Date.UTC(2026, 5, 11)
+const BEFORE_CUTOFF_MS = CACHE_HIT_RATE_CUTOFF_MS - 24 * 60 * 60 * 1000
+const AFTER_CUTOFF_MS = CACHE_HIT_RATE_CUTOFF_MS + 24 * 60 * 60 * 1000
+
+function mockFetchWithSummary(summary: Record<string, unknown>) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input)
 
@@ -18,25 +24,18 @@ function mockFetchWithCost(totalCost: number) {
 
     if (url.includes('cost_report_v2.json')) {
       return {
-        ok: false,
-        status: 404,
-        headers: { get: () => null },
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => ({ summary }),
       } as unknown as Response
     }
 
     if (url.includes('cost_report.jsonl')) {
       return {
-        ok: true,
-        status: 200,
-        headers: { get: () => 'application/json' },
-        json: async () => ({
-          summary: {
-            total_cost: totalCost,
-            total_duration: 12.3,
-            only_main_output_cost: totalCost,
-            sum_critic_files: 0,
-          },
-        }),
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
       } as unknown as Response
     }
 
@@ -45,6 +44,15 @@ function mockFetchWithCost(totalCost: number) {
 
   globalThis.fetch = fetchMock as unknown as typeof fetch
   return fetchMock
+}
+
+function mockFetchWithCost(totalCost: number) {
+  return mockFetchWithSummary({
+    total_cost: totalCost,
+    total_duration: 12.3,
+    only_main_output_cost: totalCost,
+    sum_critic_files: 0,
+  })
 }
 
 afterEach(() => {
@@ -144,6 +152,71 @@ describe('CompletedRunResults', () => {
       )
       expect(anchor?.target).toBe('_blank')
       expect(anchor?.rel).toContain('noopener')
+    })
+  })
+
+  describe('cache_hit_rate', () => {
+    function summaryWith(rate: number | null | undefined) {
+      const base: Record<string, unknown> = {
+        total_cost: 1.5,
+        total_duration: 12.3,
+        only_main_output_cost: 1.5,
+        sum_critic_files: 0,
+      }
+      // `undefined` means "key absent", i.e. legacy producer.
+      if (rate !== undefined) base.cache_hit_rate = rate
+      return base
+    }
+
+    it('renders cache_hit_rate as a percentage', async () => {
+      mockFetchWithSummary(summaryWith(0.7842))
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      await screen.findByText('cache_hit_rate')
+      expect(screen.getByText('78.42%')).toBeTruthy()
+    })
+
+    it('shows a warning when cache_hit_rate is exactly 0', async () => {
+      mockFetchWithSummary(summaryWith(0))
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      const warning = await screen.findByTestId('zero-cache-hit-warning')
+      expect(warning.textContent).toContain('Cache hit rate is 0%')
+    })
+
+    it('does not warn about zero when cache_hit_rate is non-zero', async () => {
+      mockFetchWithSummary(summaryWith(0.42))
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      await screen.findByText('Cost Report')
+      expect(screen.queryByTestId('zero-cache-hit-warning')).toBeNull()
+    })
+
+    it('does not warn about zero when cache_hit_rate is null (no input to measure)', async () => {
+      mockFetchWithSummary(summaryWith(null))
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      await screen.findByText('Cost Report')
+      expect(screen.queryByTestId('zero-cache-hit-warning')).toBeNull()
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
+    })
+
+    it('shows a missing warning when the key is absent and the run is post-cutoff', async () => {
+      mockFetchWithSummary(summaryWith(undefined))
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      const warning = await screen.findByTestId('missing-cache-hit-warning')
+      expect(warning.textContent).toContain('Cache hit rate not reported')
+    })
+
+    it('does not show a missing warning for pre-cutoff (legacy) runs', async () => {
+      mockFetchWithSummary(summaryWith(undefined))
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={BEFORE_CUTOFF_MS} />)
+      await screen.findByText('Cost Report')
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
+    })
+
+    it('does not show a missing warning when the run completion time is unknown', async () => {
+      // Old callers that don't pass runCompletedAtMs should keep working.
+      mockFetchWithSummary(summaryWith(undefined))
+      render(<CompletedRunResults slug="swebench/model/123" />)
+      await screen.findByText('Cost Report')
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
     })
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -251,6 +251,10 @@ export interface CostReportSummary {
   total_duration: number
   only_main_output_cost: number
   sum_critic_files: number
+  /** Fraction of accumulated input tokens served from cache (0–1).
+   *  `null` when the run had no input tokens to measure; `undefined`
+   *  when the producer has not been upgraded yet (pre-2026-06-11 runs). */
+  cache_hit_rate?: number | null
 }
 
 export interface CostReport {

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -6,6 +6,24 @@ import SectionMenu from './SectionMenu'
 
 interface CompletedRunResultsProps {
   slug: string
+  /** Run completion time, ms since epoch. Used to decide whether a
+   *  missing `cache_hit_rate` is expected (pre-2026-06-11 runs) or
+   *  worth flagging. Optional so legacy callers keep working. */
+  runCompletedAtMs?: number | null
+}
+
+/** Cutoff: cost_report_v2.jsonl gained `summary.cache_hit_rate` on
+ *  2026-06-11. Runs that completed before this date are not expected
+ *  to carry the field, so we suppress the "missing" warning for them. */
+const CACHE_HIT_RATE_EXPECTED_SINCE_MS = Date.UTC(2026, 5, 11)
+
+function formatSummaryValue(key: string, value: unknown): string {
+  if (value === null) return '—'
+  if (typeof value !== 'number') return String(value ?? '—')
+  if (key === 'cache_hit_rate') return `${(value * 100).toFixed(2)}%`
+  if (key.includes('cost') || key.includes('critic')) return `$${value.toFixed(4)}`
+  if (key.includes('duration')) return `${value.toFixed(1)}s`
+  return String(value)
 }
 
 function ExternalLink({ href, children }: { href: string; children: React.ReactNode }) {
@@ -60,9 +78,43 @@ function OutputReportCard({ report }: { report: OutputReport }) {
   )
 }
 
-function CostReportCard({ report }: { report: CostReport }) {
-  const totalCost = report.summary?.total_cost
+function WarningBanner({ testId, title, body }: { testId: string; title: string; body: string }) {
+  return (
+    <div
+      data-testid={testId}
+      className="mb-3 flex items-start gap-2 rounded-md border border-orange-500/40 bg-orange-500/10 p-3 text-orange-300"
+    >
+      <span className="text-sm" aria-hidden>⚠️</span>
+      <div className="text-xs">
+        <div className="font-semibold">{title}</div>
+        <div className="text-orange-200/80">{body}</div>
+      </div>
+    </div>
+  )
+}
+
+function CostReportCard({
+  report,
+  runCompletedAtMs,
+}: {
+  report: CostReport
+  runCompletedAtMs?: number | null
+}) {
+  const summary = report.summary
+  const totalCost = summary?.total_cost
   const showZeroCostWarning = typeof totalCost === 'number' && totalCost === 0
+
+  // `cache_hit_rate` may be: a number (including 0), null (run had no
+  // measurable input), or undefined (key absent — producer not upgraded).
+  const cacheHitRate = summary?.cache_hit_rate
+  const cacheHitKeyPresent = !!summary && 'cache_hit_rate' in summary
+
+  const showZeroCacheHitWarning = cacheHitRate === 0
+  const showMissingCacheHitWarning =
+    !!summary &&
+    !cacheHitKeyPresent &&
+    runCompletedAtMs != null &&
+    runCompletedAtMs >= CACHE_HIT_RATE_EXPECTED_SINCE_MS
 
   return (
     <div className="bg-oh-surface border border-oh-border rounded-lg p-4">
@@ -75,39 +127,40 @@ function CostReportCard({ report }: { report: CostReport }) {
       </div>
 
       {showZeroCostWarning && (
-        <div
-          data-testid="zero-cost-warning"
-          className="mb-3 flex items-start gap-2 rounded-md border border-orange-500/40 bg-orange-500/10 p-3 text-orange-300"
-        >
-          <span className="text-sm" aria-hidden>
-            ⚠️
-          </span>
-          <div className="text-xs">
-            <div className="font-semibold">Cost is $0.0000</div>
-            <div className="text-orange-200/80">
-              Check if cost was added to infra. Token usage was tracked, you can recalculate costs.
-            </div>
-          </div>
-        </div>
+        <WarningBanner
+          testId="zero-cost-warning"
+          title="Cost is $0.0000"
+          body="Check if cost was added to infra. Token usage was tracked, you can recalculate costs."
+        />
       )}
 
-      {report.summary ? (
+      {showZeroCacheHitWarning && (
+        <WarningBanner
+          testId="zero-cache-hit-warning"
+          title="Cache hit rate is 0%"
+          body="Prompt caching may be disabled or misconfigured — every input token is being billed at the cache-miss rate."
+        />
+      )}
+
+      {showMissingCacheHitWarning && (
+        <WarningBanner
+          testId="missing-cache-hit-warning"
+          title="Cache hit rate not reported"
+          body="cost_report_v2 is missing `cache_hit_rate`. Re-run the recalculate-costs job (or the eval-job) against a recent SDK to surface it."
+        />
+      )}
+
+      {summary ? (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <tbody>
-              {Object.entries(report.summary).map(([key, value]) => (
+              {Object.entries(summary).map(([key, value]) => (
                 <tr key={key} className="border-b border-oh-border/50 last:border-0">
                   <td className="py-1.5 pr-4 text-oh-text-muted font-mono text-xs whitespace-nowrap align-top">
                     {key}
                   </td>
                   <td className="py-1.5 text-oh-text font-mono text-xs break-all">
-                    {typeof value === 'number'
-                      ? key.includes('cost') || key.includes('critic')
-                        ? `$${value.toFixed(4)}`
-                        : key.includes('duration')
-                          ? `${value.toFixed(1)}s`
-                          : String(value)
-                      : String(value ?? '—')}
+                    {formatSummaryValue(key, value)}
                   </td>
                 </tr>
               ))}
@@ -175,7 +228,7 @@ function ArchiveLink({ slug }: { slug: string }) {
   )
 }
 
-export default function CompletedRunResults({ slug }: CompletedRunResultsProps) {
+export default function CompletedRunResults({ slug, runCompletedAtMs }: CompletedRunResultsProps) {
   const [outputReport, setOutputReport] = useState<OutputReport | null>(null)
   const [costReport, setCostReport] = useState<CostReport | null>(null)
   const [loading, setLoading] = useState(true)
@@ -220,7 +273,7 @@ export default function CompletedRunResults({ slug }: CompletedRunResultsProps) 
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {outputReport && <OutputReportCard report={outputReport} />}
-        {costReport && <CostReportCard report={costReport} />}
+        {costReport && <CostReportCard report={costReport} runCompletedAtMs={runCompletedAtMs} />}
       </div>
       <ArchiveLink slug={slug} />
     </div>

--- a/frontend/src/components/RunDetailView.tsx
+++ b/frontend/src/components/RunDetailView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { parseRunSlug, extractTriggeredBy, extractTriggerReason, extractCancelledBy, getRuntime, isFinished, fetchSubmissionData, getResultsUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl } from '../api'
+import { parseRunSlug, extractTriggeredBy, extractTriggerReason, extractCancelledBy, getRuntime, isFinished, fetchSubmissionData, getResultsUrl, isResumedRun, getOriginalRunSlug, buildOriginalRunUrl, getEndTimestamp } from '../api'
 import type { RunMetadata, SubmissionData } from '../api'
 import StatusTimeline from './StatusTimeline'
 import JsonCard from './JsonCard'
@@ -177,7 +177,12 @@ export default function RunDetailView({ slug, metadata, loading, status }: RunDe
       )}
 
       {/* Completed Run Results */}
-      {status === 'completed' && <CompletedRunResults slug={slug} />}
+      {status === 'completed' && (
+        <CompletedRunResults
+          slug={slug}
+          runCompletedAtMs={metadata ? getEndTimestamp(metadata) : null}
+        />
+      )}
 
       {/* Status Timeline */}
       {metadata && <StatusTimeline metadata={metadata} />}


### PR DESCRIPTION
## Why

`cost_report_v2.jsonl` is gaining a `summary.cache_hit_rate` field in [OpenHands/evaluation#582](https://github.com/OpenHands/evaluation/pull/582) (which itself follows [OpenHands/software-agent-sdk#3650](https://github.com/OpenHands/software-agent-sdk/pull/3650), where the SDK adds the derived `MetricsSnapshot.cache_hit_rate` property).

`CostReportCard` already renders every `summary` key generically, so technically the value will show up the moment evaluation#582 lands. But:

1. A raw `0.7842` is unhelpful — users expect a percentage in a "Cost Report".
2. A silent `0` is suspicious: prompt caching is almost certainly disabled or misconfigured when zero cache reads happen across a whole eval, and that's exactly the situation this whole feature was added to detect.
3. A silent **missing** field is even worse: it's the "the producer regressed and is no longer reporting it" failure mode — but for legacy runs that predate the producer upgrade, the field genuinely doesn't exist and we don't want false alarms.

This PR adds the targeted UI treatment for all three cases.

## What changes

### `frontend/src/components/CompletedRunResults.tsx`

- New `formatSummaryValue(key, value)` helper. Replaces the inline ternary chain that rendered cost/duration/etc., and adds a branch for `key === 'cache_hit_rate'` → `(value * 100).toFixed(2) + '%'`.
- New `WarningBanner` component, extracted from the existing zero-cost warning markup — same styling, three usages now.
- New `<CostReportCard>` warnings:
  - **`zero-cache-hit-warning`** when `summary.cache_hit_rate === 0`.
  - **`missing-cache-hit-warning`** when the key is absent from `summary` **and** `runCompletedAtMs >= 2026-06-11 UTC`. The cutoff is the date the producer upgrade lands.
  - Note: `cache_hit_rate === null` (run had no measurable input tokens — e.g. an instant failure) is treated as "intentionally unknown" — neither warning fires.
- New optional `runCompletedAtMs` prop, plumbed into the card so it can decide whether the missing-field warning is warranted. The prop is optional → existing test callers and any other site that renders `CompletedRunResults` without metadata keep working unchanged (warning is suppressed when the timestamp is unknown).

### `frontend/src/components/RunDetailView.tsx`

Passes `runCompletedAtMs={metadata ? getEndTimestamp(metadata) : null}` to `CompletedRunResults`. `getEndTimestamp` was already used elsewhere in `api.ts` for the same purpose (completion ms from `metadata.evalInferEnd.timestamp`).

### `frontend/src/api.ts`

Adds `cache_hit_rate?: number | null` to the `CostReportSummary` interface. The runtime `Object.entries(summary)` rendering was already permissive, but typing this explicitly makes the contract obvious and the per-key formatting type-safe.

### Tests (`frontend/src/__tests__/CompletedRunResults.test.tsx`)

Switched the mock to populate `cost_report_v2.json` (the actual source of `cache_hit_rate`) instead of the legacy `cost_report.jsonl`. Existing zero-cost / submit-to-index / trajectory-visualizer tests are unchanged in semantics — `mockFetchWithCost` now routes through a thinner `mockFetchWithSummary`.

New `describe('cache_hit_rate', ...)` block covers 7 cases:

| Scenario | Expectation |
|---|---|
| rate = 0.7842 (post-cutoff) | row renders `78.42%`, no warnings |
| rate = 0 (post-cutoff) | `zero-cache-hit-warning` appears |
| rate = 0.42 (post-cutoff) | no zero-warning |
| rate = `null` (post-cutoff) | neither warning (no input to measure) |
| key absent (post-cutoff) | `missing-cache-hit-warning` appears |
| key absent (pre-cutoff legacy run) | no missing-warning |
| key absent, no `runCompletedAtMs` | no missing-warning (legacy callers) |

```
$ npx vitest run src/__tests__/CompletedRunResults.test.tsx
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

`make typecheck` clean. The 18 unrelated failures in `src/__tests__/url-routing.test.ts` exist on `main` (confirmed by running it on `main` with no diff applied — same 18 failures around the `numDays` default) and are out of scope for this PR.

## Notes for reviewers

- I considered making `runCompletedAtMs` required, but that breaks every test that currently does `<CompletedRunResults slug="..." />` and every other potential caller — keeping it optional with `null` semantics ("can't tell, so don't warn") is strictly the safer default.
- The cutoff is hard-coded as `Date.UTC(2026, 5, 11)` (note: month 0-indexed → June). A tunable env / config knob felt like over-engineering for what is effectively a one-time backfill signal. Happy to swap for a `VITE_*` env var if you'd rather.
- "Missing" intentionally uses `'cache_hit_rate' in summary` (key absence) rather than `=== undefined` (value falsiness), so a producer that explicitly writes `null` doesn't trigger the warning.

Refs: [OpenHands/software-agent-sdk#3650](https://github.com/OpenHands/software-agent-sdk/pull/3650), [OpenHands/evaluation#582](https://github.com/OpenHands/evaluation/pull/582)

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/48bdeb77-ff5c-4fcc-b251-32f5c342413b)