### PR TITLE
fix(copy-command): target eval-job.yml in OpenHands/evaluation

### DIFF
--- a/frontend/src/components/CopyCommandButton.test.tsx
+++ b/frontend/src/components/CopyCommandButton.test.tsx
@@ -67,15 +67,16 @@ describe('CopyCommandButton', () => {
     fireEvent.click(copyButton)
 
     const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(call).toContain('gh workflow run run-eval.yml')
-    expect(call).toContain('--repo OpenHands/software-agent-sdk')
+    expect(call).toContain('gh workflow run eval-job.yml')
+    expect(call).toContain('--repo OpenHands/evaluation')
     expect(call).toContain('-f benchmark="swebench"')
-    expect(call).toContain('-f sdk_ref=""')
-    expect(call).toContain('-f allow_unreleased_branches="true"')
+    expect(call).toContain('-f sdk_commit=""')
+    expect(call).not.toContain('allow_unreleased_branches')
     expect(call).toContain('-f eval_limit="1"')
     expect(call).toContain('-f model_ids="minimax-m2.5"')
-    expect(call).toContain('-f reason="test eval-job-id"')
-    expect(call).toContain('-f eval_branch="main"')
+    expect(call).toContain('-f trigger_reason="test eval-job-id"')
+    expect(call).not.toContain('-f reason=')
+    expect(call).not.toContain('-f eval_branch=')
     expect(call).toContain('-f benchmarks_branch="main"')
     expect(call).toContain('-f extensions_branch=""')
     expect(call).toContain('-f instance_ids=""')
@@ -134,7 +135,6 @@ describe('CopyCommandButton', () => {
     const data = {
       benchmark: 'swebench',
       model_id: 'claude-sonnet-4',
-      evaluation_branch: 'refs/heads/feature-branch',
       benchmarks_branch: 'refs/heads/main',
     }
 
@@ -144,12 +144,13 @@ describe('CopyCommandButton', () => {
     fireEvent.click(copyButton)
 
     const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(call).toContain('-f eval_branch="feature-branch"')
     expect(call).toContain('-f benchmarks_branch="main"')
     expect(call).not.toContain('refs/heads')
+    // evaluation_branch no longer maps to a workflow input in the evaluation repo
+    expect(call).not.toContain('-f eval_branch=')
   })
 
-  it('uses sdk_commit value for sdk_ref parameter', () => {
+  it('uses sdk_commit value for sdk_commit parameter', () => {
     const data = {
       benchmark: 'swebench',
       model_id: 'claude-sonnet-4',
@@ -162,7 +163,7 @@ describe('CopyCommandButton', () => {
     fireEvent.click(copyButton)
 
     const call = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(call).toContain('-f sdk_ref="abc123def456"')
+    expect(call).toContain('-f sdk_commit="abc123def456"')
   })
 
   it('extracts extensions_branch and strips refs/heads/', () => {

--- a/frontend/src/components/CopyCommandButton.tsx
+++ b/frontend/src/components/CopyCommandButton.tsx
@@ -27,11 +27,8 @@ function extractWorkflowInputs(data: Record<string, unknown>): Record<string, st
   // benchmark
   params['benchmark'] = valueToString(data.benchmark)
 
-  // sdk_ref (value from sdk_commit field)
-  params['sdk_ref'] = valueToString(data.sdk_commit)
-
-  // allow_unreleased_branches (always true)
-  params['allow_unreleased_branches'] = 'true'
+  // sdk_commit (renamed from sdk_ref in the evaluation repo workflow)
+  params['sdk_commit'] = valueToString(data.sdk_commit)
 
   // eval_limit
   params['eval_limit'] = valueToString(data.eval_limit)
@@ -39,15 +36,8 @@ function extractWorkflowInputs(data: Record<string, unknown>): Record<string, st
   // model_ids (must exist in params, don't extract from model_name)
   params['model_ids'] = valueToString(data.model_id)
 
-  // reason (from trigger_reason)
-  params['reason'] = valueToString(data.trigger_reason)
-
-  // eval_branch (from evaluation_branch, strip refs/heads/)
-  if (data.evaluation_branch && typeof data.evaluation_branch === 'string') {
-    params['eval_branch'] = stripRefsPrefix(data.evaluation_branch)
-  } else {
-    params['eval_branch'] = ''
-  }
+  // trigger_reason (renamed from reason in the evaluation repo workflow)
+  params['trigger_reason'] = valueToString(data.trigger_reason)
 
   // benchmarks_branch
   if (data.benchmarks_branch && typeof data.benchmarks_branch === 'string') {
@@ -95,8 +85,8 @@ function extractWorkflowInputs(data: Record<string, unknown>): Record<string, st
 
 function generateGhCommand(params: Record<string, string>): string {
   const parts = [
-    'gh workflow run run-eval.yml',
-    '--repo OpenHands/software-agent-sdk',
+    'gh workflow run eval-job.yml',
+    '--repo OpenHands/evaluation',
   ]
 
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary

The "Copy command" button next to a run was generating a `gh workflow run` command targeting the now-removed `run-eval.yml` workflow in `OpenHands/software-agent-sdk`. That workflow is no longer manually dispatchable (HTTP 422: `Workflow does not have 'workflow_dispatch' trigger`), so clicking the button would produce a command that fails.

Update the generated command to dispatch `eval-job.yml` in `OpenHands/evaluation` instead, and align the parameter names with that workflow's `workflow_dispatch` inputs.

## Changes

- `frontend/src/components/CopyCommandButton.tsx`
  - `gh workflow run run-eval.yml --repo OpenHands/software-agent-sdk` → `gh workflow run eval-job.yml --repo OpenHands/evaluation`
  - `-f sdk_ref=…` → `-f sdk_commit=…`
  - `-f reason=…` → `-f trigger_reason=…`
  - Drop `-f allow_unreleased_branches="true"` (not an input on `eval-job.yml`)
  - Drop `-f eval_branch=…` (not an input on `eval-job.yml`; eval content branch is controlled by `benchmarks_branch`)

- `frontend/src/components/CopyCommandButton.test.tsx`
  - Update the all-parameters test to assert the new repo, workflow file, and renamed inputs.
  - Assert that the dropped inputs (`allow_unreleased_branches`, `-f reason=`, `-f eval_branch=`) are no longer emitted.
  - Update the `sdk_ref` and `strips refs/heads/` tests to match the new input names.

## Resulting command

```bash
gh workflow run eval-job.yml \
  --repo OpenHands/evaluation \
  -f benchmark="swebench" \
  -f sdk_commit="main" \
  -f eval_limit="1" \
  -f model_ids="gpt-5.5" \
  -f trigger_reason="single test" \
  -f benchmarks_branch="main" \
  -f extensions_branch="main" \
  -f instance_ids="" \
  -f num_infer_workers="" \
  -f num_eval_workers="" \
  -f enable_conversation_event_logging="false" \
  -f max_retries="3" \
  -f tool_preset="default" \
  -f agent_type="default" \
  -f partial_archive_url=""
```

## Verification

- `npx vitest run src/components/CopyCommandButton.test.tsx` — 12/12 tests pass.
- `npm run build` (tsc + vite) — succeeds.
- `make typecheck` — clean.

Co-authored-by: openhands <openhands@all-hands.dev>

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ec54ef3c-3cf3-4441-88b3-57dff716eb20)