### PR TITLE
feat(cost-report): surface cache_hit_rate from efficiency_summary fallback

### DIFF
--- a/frontend/src/__tests__/CompletedRunResults.test.tsx
+++ b/frontend/src/__tests__/CompletedRunResults.test.tsx
@@ -39,6 +39,93 @@ function mockFetchWithSummary(summary: Record<string, unknown>) {
       } as unknown as Response
     }
 
+    if (url.includes('efficiency_summary.json')) {
+      return {
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+      } as unknown as Response
+    }
+
+    throw new Error(`Unexpected fetch url: ${url}`)
+  })
+
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+interface FetchOptions {
+  /** Efficiency summary response body, or undefined to 404 it. */
+  efficiency?: Record<string, unknown> | null
+  /** Shape of the v1 cost_report.jsonl summary; defaults to a summary
+   *  without `cache_hit_rate` (the realistic OpenHands/benchmarks
+   *  producer on main today). Set to `null` to 404 the file. */
+  costReportSummary?: Record<string, unknown> | null
+}
+
+/** Build a fetch mock for the realistic post-#185 scenario: a v1
+ *  `cost_report.jsonl` (no cache_hit_rate) plus an optional
+ *  `efficiency_summary.json`. `cost_report_v2.json` is the missing
+ *  third file — only emitted by the separate recalculate-costs job. */
+function mockFetch(opts: FetchOptions = {}) {
+  const { efficiency, costReportSummary } = opts
+  const v1Summary = costReportSummary ?? {
+    total_cost: 1.7044946,
+    total_duration: 591.20869,
+    only_main_output_cost: 1.7044946,
+    sum_critic_files: 1.7044946,
+  }
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+
+    if (url.includes('output.report.json')) {
+      return {
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+      } as unknown as Response
+    }
+
+    if (url.includes('cost_report_v2.json')) {
+      return {
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+      } as unknown as Response
+    }
+
+    if (url.includes('cost_report.jsonl')) {
+      if (costReportSummary === null) {
+        return {
+          ok: false,
+          status: 404,
+          headers: { get: () => null },
+        } as unknown as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => ({ summary: v1Summary }),
+      } as unknown as Response
+    }
+
+    if (url.includes('efficiency_summary.json')) {
+      if (efficiency === undefined || efficiency === null) {
+        return {
+          ok: false,
+          status: 404,
+          headers: { get: () => null },
+        } as unknown as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => efficiency,
+      } as unknown as Response
+    }
+
     throw new Error(`Unexpected fetch url: ${url}`)
   })
 
@@ -216,6 +303,125 @@ describe('CompletedRunResults', () => {
       mockFetchWithSummary(summaryWith(undefined))
       render(<CompletedRunResults slug="swebench/model/123" />)
       await screen.findByText('Cost Report')
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
+    })
+  })
+
+  describe('efficiency_summary.json fallback', () => {
+    function efficiencyWith(rate: number | null | undefined) {
+      const tokens: Record<string, unknown> = {
+        prompt_tokens: 5418997,
+        completion_tokens: 22301,
+        cache_read_tokens: 4067968,
+      }
+      if (rate !== undefined) tokens.cache_hit_rate = rate
+      return {
+        schema_version: 6,
+        cost: { tokens },
+      }
+    }
+
+    it('surfaces the rate from efficiency_summary when v1 lacks cache_hit_rate', async () => {
+      // Realistic open-benchmarks-on-main scenario: v1 cost_report.jsonl
+      // exists (no cache_hit_rate), efficiency_summary.json carries
+      // cache_hit_rate = 0.7507, cost_report_v2.json absent.
+      mockFetch({ efficiency: efficiencyWith(0.7506865200331353) })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+
+      const banner = await screen.findByTestId('cache-hit-rate-from-efficiency')
+      expect(banner.textContent).toContain('Cache hit rate is 75.07%')
+      expect(banner.textContent).toContain('efficiency_summary.json')
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
+    })
+
+    it('suppresses the missing warning when efficiency ships the rate as a number', async () => {
+      mockFetch({ efficiency: efficiencyWith(0.5) })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      await screen.findByTestId('cache-hit-rate-from-efficiency')
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
+    })
+
+    it('suppresses the missing warning when efficiency ships null (no input to measure)', async () => {
+      // null in efficiency_summary.json means "we measured, but there
+      // was no input to measure" — distinct from "key absent". Treat it
+      // as a valid measurement signal: no info banner (nothing to show)
+      // and no missing warning (we have a measurement).
+      mockFetch({ efficiency: efficiencyWith(null) })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      await screen.findByText('Cost Report')
+      expect(screen.queryByTestId('cache-hit-rate-from-efficiency')).toBeNull()
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
+    })
+
+    it('still warns when efficiency exists but lacks the rate (pre-schema-6 producer)', async () => {
+      // efficiency_summary exists, schema_version 6, but no
+      // `cost.tokens.cache_hit_rate` (e.g. a producer that hasn't been
+      // upgraded past schema_version 5).
+      mockFetch({
+        efficiency: {
+          schema_version: 6,
+          cost: { tokens: { prompt_tokens: 1, completion_tokens: 1 } },
+        },
+      })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      const warning = await screen.findByTestId('missing-cache-hit-warning')
+      expect(warning.textContent).toContain('Cache hit rate not reported')
+    })
+
+    it('still warns when both cost_report and efficiency_summary lack the rate', async () => {
+      mockFetch({ efficiency: undefined })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      const warning = await screen.findByTestId('missing-cache-hit-warning')
+      expect(warning.textContent).toContain('Cache hit rate not reported')
+    })
+
+    it('falls back gracefully when efficiency_summary.json is missing entirely', async () => {
+      mockFetch({ efficiency: null })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      const warning = await screen.findByTestId('missing-cache-hit-warning')
+      expect(warning.textContent).toContain('Cache hit rate not reported')
+      // Body should match the original PR #185 copy when no efficiency file exists.
+      expect(warning.textContent).toContain('cost_report_v2')
+      expect(warning.textContent).not.toContain('Neither')
+    })
+
+    it('does not show the missing warning for pre-cutoff runs even without efficiency', async () => {
+      mockFetch({ efficiency: null })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={BEFORE_CUTOFF_MS} />)
+      await screen.findByText('Cost Report')
+      expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
+      expect(screen.queryByTestId('cache-hit-rate-from-efficiency')).toBeNull()
+    })
+
+    it('does not show the info banner when v2 already carries cache_hit_rate', async () => {
+      // When v2 ships cache_hit_rate, the table itself shows it; the
+      // info banner must NOT double up.
+      const summaryWithRate = {
+        total_cost: 1.7,
+        total_duration: 591.2,
+        only_main_output_cost: 1.7,
+        sum_critic_files: 0,
+        cache_hit_rate: 0.9,
+      }
+      mockFetch({ efficiency: efficiencyWith(0.5), costReportSummary: summaryWithRate })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      await screen.findByText('90.00%')
+      expect(screen.queryByTestId('cache-hit-rate-from-efficiency')).toBeNull()
+    })
+
+    it('shows the zero-cache-hit warning when v2 ships 0 even if efficiency has 0 too', async () => {
+      const summaryWithRate = {
+        total_cost: 1.7,
+        total_duration: 591.2,
+        only_main_output_cost: 1.7,
+        sum_critic_files: 0,
+        cache_hit_rate: 0,
+      }
+      mockFetch({ efficiency: efficiencyWith(0), costReportSummary: summaryWithRate })
+      render(<CompletedRunResults slug="swebench/model/123" runCompletedAtMs={AFTER_CUTOFF_MS} />)
+      const warning = await screen.findByTestId('zero-cache-hit-warning')
+      expect(warning.textContent).toContain('Cache hit rate is 0%')
+      expect(screen.queryByTestId('cache-hit-rate-from-efficiency')).toBeNull()
       expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
     })
   })

--- a/frontend/src/__tests__/CompletedRunResults.test.tsx
+++ b/frontend/src/__tests__/CompletedRunResults.test.tsx
@@ -330,6 +330,7 @@ describe('CompletedRunResults', () => {
 
       const banner = await screen.findByTestId('cache-hit-rate-from-efficiency')
       expect(banner.textContent).toContain('Cache hit rate is 75.07%')
+      expect(banner.textContent).toContain('Sourced from')
       expect(banner.textContent).toContain('efficiency_summary.json')
       expect(screen.queryByTestId('missing-cache-hit-warning')).toBeNull()
     })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -277,6 +277,36 @@ export async function fetchCostReport(slug: string): Promise<CostReport | null> 
   return { summary, fullUrl: getResultsUrl(cleanSlug, 'cost_report.jsonl') }
 }
 
+/** Subset of `efficiency_summary.json` we care about.
+ *  Produced by `OpenHands/evaluation#582` (eval-job's `summarize_efficiency.py`,
+ *  schema_version ≥ 6 — landed on 2026-06-11). The full file has many more
+ *  fields (concurrency, durations, retries, …); we only persist the ones the
+ *  UI consumes today so we can grow the type without churning callers. */
+export interface EfficiencySummary {
+  schema_version?: number
+  /** `cost.tokens.cache_hit_rate` — same semantics as
+   *  `CostReportSummary.cache_hit_rate`: 0–1 fraction, `null` when there was
+   *  no input to measure, key absent for pre-schema-6 producers. */
+  cache_hit_rate?: number | null
+  fullUrl: string
+}
+
+export async function fetchEfficiencySummary(slug: string): Promise<EfficiencySummary | null> {
+  const cleanSlug = slug.replace(/\/$/, '')
+  const data = await fetchJson(`${BASE_URL}/${cleanSlug}/efficiency_summary.json`)
+  if (!data) return null
+  const cost = (data.cost as Record<string, unknown> | undefined) ?? undefined
+  const tokens = (cost?.tokens as Record<string, unknown> | undefined) ?? undefined
+  const rawRate = tokens?.cache_hit_rate
+  const cache_hit_rate =
+    typeof rawRate === 'number' || rawRate === null ? rawRate : undefined
+  return {
+    schema_version: typeof data.schema_version === 'number' ? data.schema_version : undefined,
+    cache_hit_rate,
+    fullUrl: getResultsUrl(cleanSlug, 'efficiency_summary.json'),
+  }
+}
+
 export function filterScalarFields(data: Record<string, unknown>): { scalarFields: Record<string, unknown>; hasListFields: boolean } {
   const scalarFields: Record<string, unknown> = {}
   let hasListFields = false

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import type { ReactNode } from 'react'
 import {
   fetchOutputReport,
   fetchCostReport,
@@ -98,7 +99,7 @@ function WarningBanner({ testId, title, body }: { testId: string; title: string;
   )
 }
 
-function InfoBanner({ testId, title, body }: { testId: string; title: string; body: string }) {
+function InfoBanner({ testId, title, body }: { testId: string; title: string; body: ReactNode }) {
   return (
     <div
       data-testid={testId}

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react'
-import { fetchOutputReport, fetchCostReport, getResultsUrl } from '../api'
-import type { OutputReport, CostReport } from '../api'
+import {
+  fetchOutputReport,
+  fetchCostReport,
+  fetchEfficiencySummary,
+  getResultsUrl,
+} from '../api'
+import type { OutputReport, CostReport, EfficiencySummary } from '../api'
 
 import SectionMenu from './SectionMenu'
 
@@ -93,12 +98,35 @@ function WarningBanner({ testId, title, body }: { testId: string; title: string;
   )
 }
 
+function InfoBanner({ testId, title, body }: { testId: string; title: string; body: string }) {
+  return (
+    <div
+      data-testid={testId}
+      className="mb-3 flex items-start gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3 text-emerald-300"
+    >
+      <span className="text-sm" aria-hidden>ℹ️</span>
+      <div className="text-xs">
+        <div className="font-semibold">{title}</div>
+        <div className="text-emerald-200/80">{body}</div>
+      </div>
+    </div>
+  )
+}
+
 function CostReportCard({
   report,
   runCompletedAtMs,
+  efficiencySummary,
 }: {
   report: CostReport
   runCompletedAtMs?: number | null
+  /** Fallback source for `cache_hit_rate`. The eval-job's
+   *  `summarize_efficiency.py` writes `cost.tokens.cache_hit_rate` into
+   *  `efficiency_summary.json` (schema_version ≥ 6) for every run, even
+   *  when the legacy `cost_report.jsonl` producer has not been upgraded.
+   *  Used to silence the missing warning and surface the value when v2
+   *  is unavailable. */
+  efficiencySummary?: EfficiencySummary | null
 }) {
   const summary = report.summary
   const totalCost = summary?.total_cost
@@ -109,10 +137,31 @@ function CostReportCard({
   const cacheHitRate = summary?.cache_hit_rate
   const cacheHitKeyPresent = !!summary && 'cache_hit_rate' in summary
 
+  // Fallback: efficiency_summary.json ships the same field under
+  // cost.tokens.cache_hit_rate for schema_version ≥ 6. We use it as a
+  // supplementary source so the user isn't told the rate is missing
+  // when it actually lives one file over. The summary table itself is
+  // untouched — this is purely a UX nudge + warning suppression.
+  const efficiencyCacheHitRate = efficiencySummary?.cache_hit_rate
+  const hasEfficiencyCacheHitNumber =
+    efficiencySummary != null && typeof efficiencyCacheHitRate === 'number'
+  const hasEfficiencyCacheHitNull =
+    efficiencySummary != null && efficiencyCacheHitRate === null
+  // Any "we measured, here's what we found" signal — including "we
+  // measured but there was no input" — suppresses the missing warning.
+  // Only a literal `number` triggers the info banner.
+  const hasEfficiencyCacheHit =
+    hasEfficiencyCacheHitNumber || hasEfficiencyCacheHitNull
+
   const showZeroCacheHitWarning = cacheHitRate === 0
+  // The "missing" warning fires only when we have no source for the rate
+  // *anywhere*: the summary key is absent AND efficiency_summary.json
+  // didn't ship one either. A literal `null` from either side means
+  // "run had no input to measure" — that case is intentionally quiet.
   const showMissingCacheHitWarning =
     !!summary &&
     !cacheHitKeyPresent &&
+    !hasEfficiencyCacheHit &&
     runCompletedAtMs != null &&
     runCompletedAtMs >= CACHE_HIT_RATE_EXPECTED_SINCE_MS
 
@@ -142,11 +191,36 @@ function CostReportCard({
         />
       )}
 
+      {hasEfficiencyCacheHitNumber && !cacheHitKeyPresent && (
+        <InfoBanner
+          testId="cache-hit-rate-from-efficiency"
+          title={`Cache hit rate is ${(efficiencyCacheHitRate! * 100).toFixed(2)}%`}
+          body={
+            <>
+              Not in `cost_report_v2` yet — sourced from{' '}
+              <a
+                href={efficiencySummary!.fullUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-emerald-200"
+              >
+                efficiency_summary.json
+              </a>
+              .
+            </>
+          }
+        />
+      )}
+
       {showMissingCacheHitWarning && (
         <WarningBanner
           testId="missing-cache-hit-warning"
           title="Cache hit rate not reported"
-          body="cost_report_v2 is missing `cache_hit_rate`. Re-run the recalculate-costs job (or the eval-job) against a recent SDK to surface it."
+          body={
+            efficiencySummary
+              ? "Neither `cost_report_v2` nor `efficiency_summary.json` reports `cache_hit_rate` for this run. Re-run the eval-job against a recent SDK (schema_version ≥ 6) to surface it."
+              : "cost_report_v2 is missing `cache_hit_rate`. Re-run the recalculate-costs job (or the eval-job) against a recent SDK to surface it."
+          }
         />
       )}
 
@@ -231,16 +305,22 @@ function ArchiveLink({ slug }: { slug: string }) {
 export default function CompletedRunResults({ slug, runCompletedAtMs }: CompletedRunResultsProps) {
   const [outputReport, setOutputReport] = useState<OutputReport | null>(null)
   const [costReport, setCostReport] = useState<CostReport | null>(null)
+  const [efficiencySummary, setEfficiencySummary] = useState<EfficiencySummary | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    Promise.all([fetchOutputReport(slug), fetchCostReport(slug)]).then(
-      ([output, cost]) => {
+    Promise.all([
+      fetchOutputReport(slug),
+      fetchCostReport(slug),
+      fetchEfficiencySummary(slug),
+    ]).then(
+      ([output, cost, eff]) => {
         if (cancelled) return
         setOutputReport(output)
         setCostReport(cost)
+        setEfficiencySummary(eff)
         setLoading(false)
       }
     )
@@ -273,7 +353,13 @@ export default function CompletedRunResults({ slug, runCompletedAtMs }: Complete
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {outputReport && <OutputReportCard report={outputReport} />}
-        {costReport && <CostReportCard report={costReport} runCompletedAtMs={runCompletedAtMs} />}
+        {costReport && (
+          <CostReportCard
+            report={costReport}
+            runCompletedAtMs={runCompletedAtMs}
+            efficiencySummary={efficiencySummary}
+          />
+        )}
       </div>
       <ArchiveLink slug={slug} />
     </div>

--- a/frontend/src/components/CompletedRunResults.tsx
+++ b/frontend/src/components/CompletedRunResults.tsx
@@ -198,7 +198,7 @@ function CostReportCard({
           title={`Cache hit rate is ${(efficiencyCacheHitRate! * 100).toFixed(2)}%`}
           body={
             <>
-              Not in `cost_report_v2` yet — sourced from{' '}
+              Sourced from{' '}
               <a
                 href={efficiencySummary!.fullUrl}
                 target="_blank"


### PR DESCRIPTION
## Summary

`OpenHands/evaluation#582` writes `cost.tokens.cache_hit_rate` into `efficiency_summary.json` (schema_version ≥ 6, since 2026‑06‑11) for **every** eval‑job run — even when the legacy `cost_report.jsonl` producer in `OpenHands/benchmarks` hasn't shipped the v2 field yet.

The dashboard only consulted `cost_report_v2.json` (only emitted by the separate recost job) and fell back to `cost_report.jsonl`. As a result, every run produced via `eval-job.yml` with `sdk_commit=main` was flagged **"Cache hit rate not reported"**, even though the value was sitting one file over in `efficiency_summary.json`. The dashboard message implied the SDK was the bottleneck, which led to confusion (see the example report in `https://eval-monitor-git-fix-copy-command-target-evalu-fa3f03-openhands.vercel.app/?run=swebench/litellm_proxy-nemotron-3-ultra-550b-a55b%2F28547429662%2F&days=15`: `cost.tokens.cache_hit_rate = 0.7507` was already shipped).

This PR makes `CompletedRunResults` also fetch `efficiency_summary.json`, parse `cost.tokens.cache_hit_rate` into a new `EfficiencySummary` type, and render a small green info banner (data‑testid `cache-hit-rate-from-efficiency`) when the value is present in the efficiency summary but missing from the cost report. The orange **"not reported"** warning is suppressed in that case.

## Semantics preserved

| v2 (`cost_report_v2.summary`) | efficiency (`cost.tokens.cache_hit_rate`) | Result |
|---|---|---|
| `0.84` | — | % rendered in table; no info banner, no warnings |
| `0` | — | Zero‑warning fires (existing behavior) |
| absent | `0.84` | Info banner: "Cache hit rate is 84.00%, sourced from `efficiency_summary.json`"; missing warning suppressed |
| absent | `null` | No banner, missing warning suppressed (signals "we measured, nothing to measure") |
| absent | absent, post‑2026‑06‑11 | Missing warning still fires; body wording now reflects that `efficiency_summary.json` exists but didn't ship the field either |
| absent | absent, pre‑2026‑06‑11 | No warning (existing cutoff; unchanged) |
| absent | absent (no efficiency file) | Missing warning body unchanged from PR #185 — preserves the original copy verbatim when no efficiency file is present |

## Changes

- `frontend/src/api.ts`
  - Adds `EfficiencySummary` interface (subset of `efficiency_summary.json`: `schema_version`, `cache_hit_rate`, `fullUrl`).
  - Adds `fetchEfficiencySummary(slug)` that parses `cost.tokens.cache_hit_rate`, normalizing `number | null` and treating anything else as `undefined` (key absent).
- `frontend/src/components/CompletedRunResults.tsx`
  - New `InfoBanner` (green, mirrored on `WarningBanner`).
  - `CostReportCard` accepts an optional `efficiencySummary` prop.
  - Missing‑key warning suppressed when efficiency ships a number or null; otherwise fires as before (with updated body when efficiency exists but lacks the field).
  - `CompletedRunResults` parallel‑fetches the efficiency summary alongside `output.report.json` and `cost_report.jsonl`/`cost_report_v2.json`.
- `frontend/src/__tests__/CompletedRunResults.test.tsx`
  - 9 new test cases covering: realistic post‑#185 scenario, number from efficiency suppresses warning, null from efficiency suppresses warning, efficiency with no rate still warns, efficiency file missing still warns (with original PR #185 body), pre‑cutoff never warns, v2 with rate suppresses the info banner, v2 with `0` keeps the zero‑warning winning over the info banner.
  - 23/23 tests in `CompletedRunResults.test.tsx` pass. (19 failing tests in `api.test.ts` / `url-routing.test.ts` are pre‑existing on `main` and unrelated to this change — verified by `git stash` + re‑run.)

## Verification

- `make test` — same baseline as `main` (9 new passing tests; 19 pre‑existing failures elsewhere unchanged).
- `make typecheck` — clean.

## Notes for reviewers

- The summary **table itself is unchanged**: the rate from `efficiency_summary.json` is rendered in a banner, not as a synthetic row in the cost summary, because the rest of the table values come from a different file.
- If you'd rather see the rate inline in the table, that's a follow‑up: we'd want to also reconcile the case where the rate differs between the two files (currently we'd surface both — banner with efficiency, table cell with v2).
- The recost job path (`cost_report_v2.jsonl`) is untouched; when v2 exists the banner is suppressed and the table renders the value as before.

Refs OpenHands/evaluation#582

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/18165046-950d-4218-8c6e-07944589f36e)